### PR TITLE
Update minio-operator clusterrole and remove a less necessary event

### DIFF
--- a/docs/minio-operator.yaml
+++ b/docs/minio-operator.yaml
@@ -27,11 +27,13 @@ rules:
   - secrets
   - pods
   - services
+  - events
   verbs:
   - get
   - watch
   - create
   - list
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -41,6 +43,7 @@ rules:
   - create
   - list
   - patch
+  - watch
 - apiGroups:
   - miniocontroller.minio.io
   resources:

--- a/pkg/controller/cluster/controller.go
+++ b/pkg/controller/cluster/controller.go
@@ -359,7 +359,6 @@ func (c *Controller) syncHandler(key string) error {
 		return err
 	}
 
-	c.recorder.Event(mi, corev1.EventTypeNormal, SuccessSynced, MessageResourceSynced)
 	return nil
 }
 


### PR DESCRIPTION
Add event in clusterrole to make minio-operator could create event
resource to kube-apiserver.
Minio-operator also need to use statefulsets watch api in statefulset
informer.