### PR TITLE
make minio image configurable

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ package main
 
 import (
 	"flag"
+	"github.com/minio/minio-operator/pkg/constants"
 	"os"
 	"os/signal"
 	"syscall"
@@ -39,12 +40,14 @@ import (
 
 var masterURL string
 var kubeconfig string
+var imagePath string
 var onlyOneSignalHandler = make(chan struct{})
 var shutdownSignals = []os.Signal{os.Interrupt, syscall.SIGTERM}
 
 func init() {
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
 	flag.StringVar(&masterURL, "master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
+	flag.StringVar(&imagePath, "image", constants.DefaultMinioImagePath, "The minio image path.")
 }
 
 func main() {
@@ -80,7 +83,8 @@ func main() {
 	controller := cluster.NewController(kubeClient, controllerClient,
 		kubeInformerFactory.Apps().V1().StatefulSets(),
 		minioInformerFactory.Minio().V1beta1().MinioInstances(),
-		kubeInformerFactory.Core().V1().Services())
+		kubeInformerFactory.Core().V1().Services(),
+		imagePath)
 
 	go kubeInformerFactory.Start(stopCh)
 	go minioInformerFactory.Start(stopCh)

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -41,7 +41,7 @@ const MinioVolumeMountPath = "/export"
 const MinioVolumeSubPath = ""
 
 // MinioImagePath specifies the Minio Docker hub path
-const MinioImagePath = "minio/minio"
+const DefaultMinioImagePath = "minio/minio"
 
 // DefaultMinioImageVersion specifies the latest released Minio Docker hub image
 const DefaultMinioImageVersion = "RELEASE.2018-11-22T02-51-56Z"

--- a/pkg/controller/mirror/mirror_controller.go
+++ b/pkg/controller/mirror/mirror_controller.go
@@ -35,7 +35,7 @@ import (
 	appsinformers "k8s.io/client-go/informers/apps/v1"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
-	scheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/kubernetes/scheme"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	appslisters "k8s.io/client-go/listers/apps/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
@@ -48,9 +48,8 @@ import (
 	minioscheme "github.com/minio/minio-operator/pkg/client/clientset/versioned/scheme"
 	informers "github.com/minio/minio-operator/pkg/client/informers/externalversions/miniocontroller/v1beta1"
 	listers "github.com/minio/minio-operator/pkg/client/listers/miniocontroller/v1beta1"
-	constants "github.com/minio/minio-operator/pkg/constants"
-	services "github.com/minio/minio-operator/pkg/resources/services"
-	statefulsets "github.com/minio/minio-operator/pkg/resources/statefulsets"
+	"github.com/minio/minio-operator/pkg/resources/services"
+	"github.com/minio/minio-operator/pkg/resources/statefulsets"
 )
 
 const controllerAgentName = "minio-operator"
@@ -106,6 +105,9 @@ type Controller struct {
 	// recorder is an event recorder for recording Event resources to the
 	// Kubernetes API.
 	recorder record.EventRecorder
+
+	// minio image
+	imagePath string
 }
 
 // NewController returns a new sample controller
@@ -114,7 +116,8 @@ func NewController(
 	minioClientSet clientset.Interface,
 	statefulSetInformer appsinformers.StatefulSetInformer,
 	minioInstanceInformer informers.MinioInstanceInformer,
-	serviceInformer coreinformers.ServiceInformer) *Controller {
+	serviceInformer coreinformers.ServiceInformer,
+	imagePath string) *Controller {
 
 	// Create event broadcaster
 	// Add minio-controller types to the default Kubernetes Scheme so Events can be
@@ -137,6 +140,7 @@ func NewController(
 		serviceListerSynced:     serviceInformer.Informer().HasSynced,
 		workqueue:               queue.NewNamedRateLimitingQueue(queue.DefaultControllerRateLimiter(), "MinioInstances"),
 		recorder:                recorder,
+		imagePath:               imagePath,
 	}
 
 	glog.Info("Setting up event handlers")
@@ -304,7 +308,7 @@ func (c *Controller) syncHandler(key string) error {
 	ss, err := c.statefulSetLister.StatefulSets(mi.Namespace).Get(mi.Name)
 	// If the resource doesn't exist, we'll create it
 	if errors.IsNotFound(err) {
-		ss = statefulsets.NewForCluster(mi, svc.Name)
+		ss = statefulsets.NewForCluster(mi, svc.Name, c.imagePath)
 		_, err = c.kubeClientSet.AppsV1().StatefulSets(mi.Namespace).Create(ss)
 	}
 
@@ -328,17 +332,17 @@ func (c *Controller) syncHandler(key string) error {
 	// should update the StatefulSet resource.
 	if mi.Spec.Replicas != *ss.Spec.Replicas {
 		glog.V(4).Infof("MinioInstance %s replicas: %d, StatefulSet replicas: %d", name, mi.Spec.Replicas, *ss.Spec.Replicas)
-		ss = statefulsets.NewForCluster(mi, svc.Name)
+		ss = statefulsets.NewForCluster(mi, svc.Name, c.imagePath)
 		_, err = c.kubeClientSet.AppsV1().StatefulSets(mi.Namespace).Update(ss)
 	}
 
 	// If this container version on the MinioInstance resource is specified, and the
 	// version does not equal the current desired version in the StatefulSet, we
 	// should update the StatefulSet resource.
-	currentVersion := strings.TrimPrefix(ss.Spec.Template.Spec.Containers[0].Image, constants.MinioImagePath+":")
+	currentVersion := strings.TrimPrefix(ss.Spec.Template.Spec.Containers[0].Image, c.imagePath+":")
 	if mi.Spec.Version != currentVersion {
 		glog.V(4).Infof("Updating MinioInstance %s Minio server version %d, to: %d", name, mi.Spec.Version, currentVersion)
-		ss = statefulsets.NewForCluster(mi, svc.Name)
+		ss = statefulsets.NewForCluster(mi, svc.Name, c.imagePath)
 		_, err = c.kubeClientSet.AppsV1().StatefulSets(mi.Namespace).Update(ss)
 	}
 

--- a/pkg/resources/statefulsets/statefulset.go
+++ b/pkg/resources/statefulsets/statefulset.go
@@ -93,7 +93,7 @@ func volumeMounts(mi *miniov1beta1.MinioInstance) []corev1.VolumeMount {
 }
 
 // Builds the Minio container for a MinioInstance.
-func minioServerContainer(mi *miniov1beta1.MinioInstance, serviceName string) corev1.Container {
+func minioServerContainer(mi *miniov1beta1.MinioInstance, serviceName, imagePath string) corev1.Container {
 	replicas := int(mi.Spec.Replicas)
 	minioPath := path.Join(mi.Spec.Mountpath, mi.Spec.Subpath)
 
@@ -113,7 +113,7 @@ func minioServerContainer(mi *miniov1beta1.MinioInstance, serviceName string) co
 
 	return corev1.Container{
 		Name:  constants.MinioServerName,
-		Image: fmt.Sprintf("%s:%s", constants.MinioImagePath, mi.Spec.Version),
+		Image: fmt.Sprintf("%s:%s", imagePath, mi.Spec.Version),
 		Ports: []corev1.ContainerPort{
 			{
 				ContainerPort: constants.MinioPort,
@@ -126,7 +126,7 @@ func minioServerContainer(mi *miniov1beta1.MinioInstance, serviceName string) co
 }
 
 // NewForCluster creates a new StatefulSet for the given Cluster.
-func NewForCluster(mi *miniov1beta1.MinioInstance, serviceName string) *appsv1.StatefulSet {
+func NewForCluster(mi *miniov1beta1.MinioInstance, serviceName, imagePath string) *appsv1.StatefulSet {
 	// If a PV isn't specified just use a EmptyDir volume
 	var podVolumes = []corev1.Volume{}
 	if mi.Spec.VolumeClaimTemplate == nil {
@@ -168,7 +168,7 @@ func NewForCluster(mi *miniov1beta1.MinioInstance, serviceName string) *appsv1.S
 		})
 	}
 
-	containers := []corev1.Container{minioServerContainer(mi, serviceName)}
+	containers := []corev1.Container{minioServerContainer(mi, serviceName, imagePath)}
 
 	podLabels := map[string]string{
 		constants.InstanceLabel: mi.Name,


### PR DESCRIPTION
In our environment, we are not allowed to use images from docker hub. This pull request makes the minio image configurable via a command line argument. So a custom registry can be used.