### PR TITLE
Add support for running in standalone mode

### DIFF
--- a/docs/minio-examples/minioinstance.yaml
+++ b/docs/minio-examples/minioinstance.yaml
@@ -3,7 +3,9 @@ kind: MinIOInstance
 metadata:
   name: minio
 spec:
-  ## Supply number of replicas, (should be an even number).
+  ## Supply number of replicas.
+  ## For standalone mode, supply 1. For distributed mode, supply 4 or more (should be even).
+  ## Note that the operator does not support upgrading from standalone to distributed mode.
   replicas: 4
   ## MinIO release version, (minio/minio image tag).
   version: RELEASE.2019-06-19T18-24-42Z

--- a/pkg/resources/statefulsets/statefulset.go
+++ b/pkg/resources/statefulsets/statefulset.go
@@ -109,9 +109,14 @@ func minioServerContainer(mi *miniov1beta1.MinIOInstance, serviceName, imagePath
 		"server",
 	}
 
-	// append all the MinIOInstance replica URLs
-	for i := 0; i < replicas; i++ {
-		args = append(args, fmt.Sprintf("%s://%s-"+strconv.Itoa(i)+".%s.%s.svc.cluster.local%s", scheme, mi.Name, serviceName, mi.Namespace, minioPath))
+	if replicas == 1 {
+		// to run in standalone mode we must pass the path
+		args = append(args, constants.MinIOVolumeMountPath)
+	} else {
+		// append all the MinIOInstance replica URLs
+		for i := 0; i < replicas; i++ {
+			args = append(args, fmt.Sprintf("%s://%s-"+strconv.Itoa(i)+".%s.%s.svc.cluster.local%s", scheme, mi.Name, serviceName, mi.Namespace, minioPath))
+		}
 	}
 
 	return corev1.Container{


### PR DESCRIPTION
For our purposes with the [Mattermost Operator](https://github.com/mattermost/mattermost-operator) we would like to be able to spin up single node MinIO deployments for special cases where we're trying to run many tiny Mattermost deployments on a single Kubernetes cluster.