### PR TITLE
fix tls names for volumes

### DIFF
--- a/pkg/resources/statefulsets/statefulset.go
+++ b/pkg/resources/statefulsets/statefulset.go
@@ -112,7 +112,7 @@ func volumeMounts(mi *miniov1beta1.MinIOInstance) []corev1.VolumeMount {
 
 	if mi.RequiresSSLSetup() {
 		mounts = append(mounts, corev1.VolumeMount{
-			Name:      mi.Name + "TLS",
+			Name:      mi.Name + "-tls",
 			MountPath: "/root/.minio/certs",
 		})
 	}
@@ -173,7 +173,7 @@ func NewForCluster(mi *miniov1beta1.MinIOInstance, serviceName, imagePath string
 	// Add SSL volume from SSL secret to the podVolumes
 	if mi.RequiresSSLSetup() {
 		podVolumes = append(podVolumes, corev1.Volume{
-			Name: mi.Name + "TLS",
+			Name: mi.Name + "-tls",
 			VolumeSource: corev1.VolumeSource{
 				Projected: &corev1.ProjectedVolumeSource{
 					Sources: []corev1.VolumeProjection{


### PR DESCRIPTION
[spec.volumes[1].name: Invalid value:
"testyTLS": a DNS-1123 label must consist of lower case
alphanumeric characters or '-', and must start and end with
an alphanumeric character (e.g. 'my-name',  or '123-abc',
egex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')