### PR TITLE
Add Go Test and Go Vet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,9 @@ build:
 
 install: all
 	@docker push $(TAG)
+
+govet:
+	go vet ./...
+
+gotest:
+	go test ./...

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	github.com/davecgh/go-spew v1.1.1
+	github.com/evanphx/json-patch v4.5.0+incompatible // indirect
 	github.com/ghodss/yaml v0.0.0-20180820084758-c7ce16629ff4
 	github.com/gogo/protobuf v0.0.0-20170702163824-dda3e8acadcc
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
@@ -19,8 +20,9 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
 	github.com/modern-go/reflect2 v1.0.1
 	github.com/peterbourgon/diskv v0.0.0-20180312054125-0646ccaebea1
+	github.com/pkg/errors v0.8.1 // indirect
 	github.com/spf13/pflag v1.0.3
-	github.com/stretchr/testify v1.3.0 // indirect
+	github.com/stretchr/testify v1.3.0
 	golang.org/x/crypto v0.0.0-20180808211826-de0752318171
 	golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/evanphx/json-patch v4.5.0+incompatible h1:ouOWdg56aJriqS0huScTkVXPC5IcNrDCXZ6OoTAWu7M=
+github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/ghodss/yaml v0.0.0-20180820084758-c7ce16629ff4 h1:bRzFpEzvausOAt4va+I/22BZ1vXDtERngp0BNYDKej0=
 github.com/ghodss/yaml v0.0.0-20180820084758-c7ce16629ff4/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gogo/protobuf v0.0.0-20170702163824-dda3e8acadcc h1:GvfI9UViag4LjQk95XUXCywcUNxbMEQEQqe/BgaFEig=
@@ -34,6 +36,8 @@ github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/peterbourgon/diskv v0.0.0-20180312054125-0646ccaebea1 h1:k/dnb0bixQwWsDLxwr6/w7rtZCVDKdbQnGQkeZGYsws=
 github.com/peterbourgon/diskv v0.0.0-20180312054125-0646ccaebea1/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=

--- a/pkg/apis/miniocontroller/v1beta1/helper_test.go
+++ b/pkg/apis/miniocontroller/v1beta1/helper_test.go
@@ -1,0 +1,50 @@
+package v1beta1
+
+import (
+	"testing"
+
+	constants "github.com/minio/minio-operator/pkg/constants"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnsureDefaults(t *testing.T) {
+	mi := MinIOInstance{}
+	mi.EnsureDefaults()
+
+	t.Run("defaults", func(t *testing.T) {
+		assert.Equal(t, mi.Spec.Replicas, int32(constants.DefaultReplicas))
+		assert.Equal(t, mi.Spec.Image, constants.DefaultMinIOImage)
+		assert.Equal(t, mi.Spec.Mountpath, constants.MinIOVolumeMountPath)
+		assert.Equal(t, mi.Spec.Subpath, constants.MinIOVolumeSubPath)
+		assert.False(t, mi.RequiresAutoCertSetup())
+	})
+
+	t.Run("auto cert", func(t *testing.T) {
+		mi.Spec.RequestAutoCert = true
+		assert.True(t, mi.RequiresAutoCertSetup())
+		assert.False(t, mi.HasCertConfig())
+
+		mi.EnsureDefaults()
+
+		require.NotNil(t, mi.Spec.CertConfig)
+		require.True(t, mi.HasCertConfig())
+		oldCertConfig := mi.Spec.CertConfig
+
+		mi.EnsureDefaults()
+
+		assert.Equal(t, oldCertConfig, mi.Spec.CertConfig)
+	})
+
+	t.Run("defaults don't override", func(t *testing.T) {
+		newImage := "minio/minio:latest"
+		newReplicas := int32(99)
+		mi.Spec.Image = newImage
+		mi.Spec.Replicas = newReplicas
+
+		mi.EnsureDefaults()
+
+		assert.Equal(t, newImage, mi.Spec.Image)
+		assert.Equal(t, newReplicas, mi.Spec.Replicas)
+	})
+}

--- a/pkg/apis/miniocontroller/v1beta1/types.go
+++ b/pkg/apis/miniocontroller/v1beta1/types.go
@@ -60,7 +60,7 @@ type MinIOInstanceSpec struct {
 	Replicas int32 `json:"replicas,omitempty"`
 	// Pod Management Policy for pod created by StatefulSet
 	// +optional
-	PodManagementPolicy appsv1.PodManagementPolicyType `json:"podManagementPolicy, omitempty"`
+	PodManagementPolicy appsv1.PodManagementPolicyType `json:"podManagementPolicy,omitempty"`
 	// Metadata defines the object metadata passed to each pod that is a part of this MinIOInstance
 	Metadata *metav1.ObjectMeta `json:"metadata,omitempty"`
 	// If provided, use this secret as the credentials for MinIOInstance resource

--- a/pkg/controller/cluster/controller.go
+++ b/pkg/controller/cluster/controller.go
@@ -363,7 +363,7 @@ func (c *Controller) syncHandler(key string) error {
 	// version does not equal the current desired version in the StatefulSet, we
 	// should update the StatefulSet resource.
 	if mi.Spec.Image != ss.Spec.Template.Spec.Containers[0].Image {
-		glog.V(4).Infof("Updating MinIOInstance %s MinIO server version %d, to: %d", name, mi.Spec.Image, ss.Spec.Template.Spec.Containers[0].Image)
+		glog.V(4).Infof("Updating MinIOInstance %s MinIO server version %s, to: %s", name, mi.Spec.Image, ss.Spec.Template.Spec.Containers[0].Image)
 		ss = statefulsets.NewForCluster(mi, svc.Name)
 		_, err = c.kubeClientSet.AppsV1().StatefulSets(mi.Namespace).Update(ss)
 	}


### PR DESCRIPTION
This change introduces two code checks to the Makefile:
 - go vet ./...
 - go test ./...

Both of these were initially failing due to mirror controller code
that would not compile. Go vet also pointed out some other print
formatting fixes that were needed which were corrected.

Ideally, these checks, along with others in the future, could be
automated in CI/CD for every PR against the repository.