### PR TITLE
controller: use glog info instead of printf to stdout

### DIFF
--- a/pkg/controller/cluster/controller.go
+++ b/pkg/controller/cluster/controller.go
@@ -243,7 +243,7 @@ func (c *Controller) processNextWorkItem() bool {
 			runtime.HandleError(fmt.Errorf("expected string in workqueue but got %#v", obj))
 			return nil
 		}
-		fmt.Printf("Key from workqueue: %s", key)
+		glog.V(2).Infof("Key from workqueue: %s\n", key)
 		// Run the syncHandler, passing it the namespace/name string of the
 		// MinIOInstance resource to be synced.
 		if err := c.syncHandler(key); err != nil {
@@ -269,7 +269,7 @@ func (c *Controller) processNextWorkItem() bool {
 func (c *Controller) syncHandler(key string) error {
 	// Convert the namespace/name string into a distinct namespace and name
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
-	fmt.Printf("Key after splitting, namespace: %s, name: %s", namespace, name)
+	glog.V(2).Infof("Key after splitting, namespace: %s, name: %s\n", namespace, name)
 	if err != nil {
 		runtime.HandleError(fmt.Errorf("Invalid resource key: %s", key))
 		return nil

--- a/pkg/controller/cluster/controller.go
+++ b/pkg/controller/cluster/controller.go
@@ -243,7 +243,7 @@ func (c *Controller) processNextWorkItem() bool {
 			runtime.HandleError(fmt.Errorf("expected string in workqueue but got %#v", obj))
 			return nil
 		}
-		glog.V(2).Infof("Key from workqueue: %s\n", key)
+		glog.V(2).Infof("Key from workqueue: %s", key)
 		// Run the syncHandler, passing it the namespace/name string of the
 		// MinIOInstance resource to be synced.
 		if err := c.syncHandler(key); err != nil {
@@ -269,7 +269,7 @@ func (c *Controller) processNextWorkItem() bool {
 func (c *Controller) syncHandler(key string) error {
 	// Convert the namespace/name string into a distinct namespace and name
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
-	glog.V(2).Infof("Key after splitting, namespace: %s, name: %s\n", namespace, name)
+	glog.V(2).Infof("Key after splitting, namespace: %s, name: %s", namespace, name)
 	if err != nil {
 		runtime.HandleError(fmt.Errorf("Invalid resource key: %s", key))
 		return nil


### PR DESCRIPTION
The logs are not readable, and don't use glog as the rest of the code does.
```
r splitting, namespace: velero, name: minioKey from workqueue: velero/minioKey after splitting, namespace: velero, name: minioKey from workqueue: velero/minioKey after splitting, namespace: velero, name: minioKey from workqueue: velero/minioKey after splitting, namespace: velero, name: minioKey from workqueue: velero/minioKey after splitting, namespace: velero, name: minioKey from workqueue: velero/minioKey after splitting, namespace: velero, name: minioKey from workqueue: velero/minioKey after splitting, namespace: velero, name: minioKey from workqueue: velero/minioKey after splitting, namespace: velero, name: minioKey from workqueue: velero/minioKey after splitting, namespace: velero, name: minioKey from workqueue: velero/minioKey after splitting, namespace: velero, name: minioKey from workqueue: velero/minioKey after splitting, namespace: velero, name: minioKey from workqueue: velero/minioKey after splitting, namespace: velero, name: minioKey from workqueue: velero/minioKey after splitting, namespace: velero, name: minioKey from workqueue: velero/minioKey after splitting, namespace:
```