### PR TITLE
update deployment apiVersion. v1beta1 is deprecated on 1.16 k8s

### DIFF
--- a/minio-operator.yaml
+++ b/minio-operator.yaml
@@ -109,20 +109,23 @@ subjects:
   name: minio-operator-sa
   namespace: minio-operator-ns
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: minio-operator
   namespace: minio-operator-ns
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: minio-operator
   template:
     metadata:
       labels:
-        app: minio-operator
+        name: minio-operator
     spec:
       serviceAccountName: minio-operator-sa
       containers:
-      - name: minio-operator
-        image: minio/k8s-operator:1.0.1
----
+        - name: minio-operator
+          image: minio/k8s-operator:1.0.4
+          imagePullPolicy: IfNotPresent


### PR DESCRIPTION
v1beta1 is deprecated on 1.16 K8s clusters. Updating the apiVersion for MinIO deployment and also bump to use the latest image released


also fixes: https://github.com/minio/minio-operator/issues/44