### PR TITLE
Improve docs and add column for minioinstances crd when print

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ MinIO is a high performance distributed object storage server, designed for larg
 To start MinIO-Operator, use the `docs/minio-operator.yaml` file.
 
 ```
-kubectl create -f https://github.com/minio/minio-operator/blob/master/minio-operator.yaml?raw=true
+kubectl create -f https://raw.githubusercontent.com/minio/minio-operator/master/minio-operator.yaml
 ```
 
 This will create all relevant resources required for the Operator to work. Here is a list of resources created by above `yaml` file:
@@ -39,7 +39,7 @@ This will create all relevant resources required for the Operator to work. Here 
 Once MinIO-Operator deployment is running, you can create MinIO instances using the below command
 
 ```
-kubectl create -f https://github.com/minio/minio-operator/blob/master/examples/minioinstance.yaml?raw=true
+kubectl create -f https://raw.githubusercontent.com/minio/minio-operator/master/examples/minioinstance.yaml
 ```
 
 ## Features
@@ -49,7 +49,7 @@ MinIO-Operator currently supports following features:
 - Create and delete highly available distributed MinIO clusters.
 - Upgrading existing distributed MinIO clusters.
 
-Refer [`minioinstance.yaml`](https://github.com/minio/minio-operator/blob/master/examples/minioinstance.yaml?raw=true) for details on how to pass supported fields to the operator.
+Refer [`minioinstance.yaml`](https://raw.githubusercontent.com/minio/minio-operator/master/examples/minioinstance.yaml) for details on how to pass supported fields to the operator.
 
 ## Upcoming features
 

--- a/minio-operator.yaml
+++ b/minio-operator.yaml
@@ -36,6 +36,10 @@ spec:
               type: string
             subpath:
               type: string
+  additionalPrinterColumns:
+    - name: Replicas
+      type: integer
+      JSONPath: ".spec.replicas"
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole


### PR DESCRIPTION
1. Update docs from "https://github.com/minio/minio-operator/blob/master/minio-operator.yaml?raw=true" to "https://github.com/minio/minio-operator/blob/master/minio-operator.yaml?raw=true", The reason is that for some env, https://github.com/${FILE}?raw=true may throw an error. Example here:
kubectl --kubeconfig ~/.kube/sjzyd-prod.yaml create -f https://github.com/minio/minio-operator/blob/master/minio-operator.yaml?raw=true
zsh: no matches found: https://github.com/minio/minio-operator/blob/master/minio-operator.yaml?raw=true

2. Add replicas to be printed when get minioinstances, when run `kubectl get minioinstances -n minio`, we'd better print replicas as it is important info for this instance.
Before:
```
NAME    AGE
minio   109m
```
After:
```
NAME    REPLICAS
minio   3
```