### PR TITLE
Track the minio OLM catalog within the minio-operator repo

### DIFF
--- a/olm-catalog/minio-operator/1.0.3/minio-operator.v1.0.3.clusterserviceversion.yaml
+++ b/olm-catalog/minio-operator/1.0.3/minio-operator.v1.0.3.clusterserviceversion.yaml
@@ -1,0 +1,272 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: minio-operator.v1.0.3
+  namespace: placeholder
+  annotations:
+    categories: 'Storage,    Big Data, AI/Machine Learning'
+    certified: 'false'
+    description: ' MinIO Operator allows creating distributed MinIO Clusters and manage their lifecycle'
+    containerImage: 'minio/k8s-operator:1.0.3'
+    support: 'MinIO, Inc.'
+    capabilities: Full Lifecycle
+    repository: 'https://github.com/minio/minio-operator'
+    createdAt: 2019-10-21T00:00:00.000Z
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "v1",
+          "kind": "Secret",
+          "metadata": {
+            "name": "minio-creds-secret"
+          },
+          "data": {
+              "accesskey": "bWluaW8=",
+              "secretkey": "bWluaW8xMjM="
+          }
+        },
+        {
+          "apiVersion": "miniocontroller.min.io/v1beta1",
+          "kind": "MinIOInstance",
+          "metadata": {
+            "name": "minio"
+          },
+          "spec": {
+            "replicas": 4,
+            "credsSecret": {
+              "name": "minio-creds-secret"
+            },
+            "requestAutoCert": false
+          }
+        }
+      ]
+spec:
+  displayName: MinIO Operator
+  description: >
+    ## About the managed application
+
+    MinIO object storage platform enables building high performance data
+    infrastructure for machine learning, analytics and application data
+    workloads. MinIO is Open Source, Enterprise-Grade, Amazon S3 Compatible
+    Object Storage. Some of the key features are:
+
+    * SQL Select
+
+    * Encryption & WORM
+
+    * Multi-Site Federation
+
+    * Lambda Compute
+
+    * Integration with IAM Tools
+
+    * Erasure Code & Bitrot Protection
+
+    ## About this Operator
+
+    MinIO Operator provides the following features:
+
+
+    * Deploy: Launch MinIO Clusters with specific affinity, toleration and other
+    pre-defined settings
+
+    * Automatic TLS: Deploy TLS enabled MinIO clusters with builtin certificate
+    signing requests.
+
+    * Configure: Configure the fundamentals of MinIO like versions, persistence,
+    erasure code configuration, and replicas.
+
+  maturity: stable
+  version: 1.0.3
+  replaces: ''
+  minKubeVersion: 1.14.0
+  keywords:
+    - Object Storage
+    - Private Cloud
+    - S3 API
+    - Cloud Storage
+  maintainers:
+    - name: MinIO Developers
+      email: dev@min.io
+  provider:
+    name: 'MinIO, Inc.'
+  labels: {}
+  selector:
+    matchLabels: {}
+  links:
+    - name: MinIO Website
+      url: 'https://www.min.io'
+    - name: MinIO Documentation
+      url: 'https://docs.min.io'
+    - name: MinIO Operator Repository
+      url: 'https://github.com/minio/minio-operator'
+  icon:
+    - base64data: >-
+        iVBORw0KGgoAAAANSUhEUgAAAKcAAACnCAYAAAB0FkzsAAAACXBIWXMAABcRAAAXEQHKJvM/AAAIj0lEQVR4nO2dT6hVVRSHjykI/gMDU0swfKAi2KgGOkv6M1RpqI9qZBYo9EAHSaIopGCQA8tJDXzNgnRcGm+SgwLDIFR4omBmCQrqE4Tkxu/6Tlyv7569zzn73Lvu3t83VO+5HN/31t5r7bX3ntVqtVoZgD0mnuOHAlZBTjALcoJZkBPMgpxgFuQEsyAnmAU5wSzICWZBTjALcoJZkBPMgpxgFuQEsyAnmAU5wSzICWZBTjDLHH40Yfn3/lR299zP2Z2z57PH9x889exFr72SLd60MZu/dtXwv2gfYA9RICTl9SNfZbfP/Oh84Lw1q7KX9+5oywo9mUDOANw5dz6b/ORY9vjBVKmHLX59QzZyeCybs3C+0TcbKMhZl9tnfsgm931e+SmKouu+OYqgz8Luyzrc++ViLTHFw8tXsz/e39OeFsDTIGcNJvcdC/IcCXpl14EBvYVdkLMiGs4f3fwn2PPu/fp79tep031+C9sgZ0V8RJr74gvZks1vZIteXe/1JTdOjGePbv49kPexCHXOCkggDcVFrNi5LVvx4fb//4U+c3nXwcLPKdtX1q8ECYiclXj0Z3F0U4moU8ysHUWXtqVTdl6EhneVpgA5KzF1qThqLh/dMuOfq1zkI6iiJ9k7claie1myDLmgmo/2QsO75p+pg5wVcC07upIaCbr6i/3Z7AW9C++3xk+366gpg5wVmL1wQeGHrn120jn0q/lDEbRI0GtHTvbpjWyCnBWQWK5hWas+rgjqElSZfcq1T+SsyJLNbxZ+UIKqdORKbFyCau6ZanKEnBVZNrq1cEjOSqyb54LORF77TBHkrIiSGrW7uSgj6Mihj2f8u7s/nU8yOULOGjy/aUO2bPvMNc1OfAXVVKGXoKGaTIYJ5KxJu6PdY+28rqBqMkmt9omcAVh9fL9z1Scr0RrXS1Bl7ik1hiBnAHyXJbPptXOfIVqCdk8ZUkuOkDMQZQTVJjgfQTVlUMtdJyk1hiBnQJoQdOTQ2DOCapdnCrVP5AxMPwRVcnTr1PeG3roZkLMBfDqPcqoKeuPLb6NPjpCzIXw6j3IkqE+ThwTtjMixJ0fI2SA+nUc5apHTpjkXnVOG2JMj5GyYMoJqD7xL0O45bczJEXL2gSYFjXnlCDn7RJOCakrgam4eRpCzj5QV1DWfzAXV8zS8xwZy9pmi3s1ulI27ImIuaIzzTk6ZGxC+p9OpVrr+uxMpnkLHKXODoqh3sxMlPKke8oWcA8RXUNUzfWqgsYGcA8ZX0BQ3uiFnn9A6uNbQZ6pJStDuzqNuNLzfPp1W9ETOhlG0k5AX3n6v8DIDrZu7tnvcGo+/E6kT5GwQzRMvvPVuu4PIB9duTkXPlE6gQ84G0BCuzWwqFZW5YUPHJOpczyJ0x1EqIGdgtAnt4jsftTPsKizZUnySSEr715EzEHm0vH70ZOn7iDpR9NThs73Q0J7KDkzkDIDmgXWiZTfOIxYdJyvHAnLWRB3sV3YfrBUtu3HJmcrQzoUFFVGJSMO46+KCKnBx6xOQswLqFJKYIaMlPAtylkS1S51cjJjNg5wlqHsJK5QDOT3REqTvSk9duOblCcjpgRo2fC75F9oyUXfIf3hpsvDv5760tNbzhwVKSQ7KiKnGDZ/Tjl241s9VqE8B5CygjJg6rjDUpf6u9XNXHTQWGNZ7oDVyXzHVLOy6XcMXFdiLrsr2vYE4BoicM6CsXGvkPoQUM5tOvIpYvGljsO+yDpGzC833fMpFSnw0jIdczdEvhWt93tW1FBNEzg608uNzclsTYqrTSMX9IrSVI6Utwsg5jWqLV3YfcJaBmhBT363b3lzf3X2He+wg5zTaG16UiOSsOf5pcDF9GkgUNVMpIeUg53QS4tOLqeQnZBlHmbn2GLnEVLReufeDYN87LCSfEEkQn2XJlXt2BMvKNb/UL4R3qerwWIrH0aQtZz7Xc6Ehdfmo+xpBH5SRl1mj13frGsMUSXpYV2buSkJ0/qX2lIfCZ16bo71EIb972EhWTtUzdRtvEXlmPghCrdMPM0kO6xrOfeqZyswHMdfTUJ5yxMxJUk4lI86a4s5tpTNzSe9zZUsvFKlVyww1vx12kpNT2bnOUC9C88wyBW9JqRvV1CxStZczH8ZTq2UWkZycrsYKRS8N5z6EkFInF7cP8UqkDa4MScnp01ihIdUneklIn+lBLySlonPIjqbYSEpOV9T0Gc7bdcoT46VKQp0gpT/JyCmpXELpfvOiz9eRMufJQbGI6UMycvq0o80071MCpQy8iZM9oJgk5FTUK5ob5iWcTtpr7p4NIdAMScjpmmt2JkFIaYfo5XTNNRU1l41urS2lniPJ560daZ86B/WJXk6VfIpQ47AajetKKcG11JnSycNNE7Wc2hPkSmTqDN9KotQEnGKvZT+IWs6mrkaRlEqgWGpslmjl1NLinbNhr0VByv4SrZw60iXUGZpIORiilTNE1ETKwRKlnBrSXV3uRSClDaKUs+otZ0hpiyjlLDukI6VN4oycnkM6UtomOjl9btVFyuEgOjmLlg+RcrhIQk6kHE6iklMlpM61dKQcbqKSM78iRdts1ZDBHZLDTXTD+rqvj7DNNhKikhMp44LDY8EsyAlmQU4wC3KCWZATzIKcYBbkBLMgJ5gFOcEsyAlmQU4wC3KCWZATzIKcYBbkBLMgJ5gFOcEsyAlmQU4wC3KCWZATzIKcYBbkBLMgJ5gFOcEsyAlmQU4wC3KCWZATzIKcgdFJdzq0FuqDnA0wcmgMQQOAnA2BoPVBzgZB0HogZ8MgaHWQsw8gaDWivdLaGhIUyjGr1Wq1+D/rH1OXrnIFjR8TyAlWmWDOCWZBTjALcoJZkBPMgpxgFuQEsyAnmAU5wSzICWZBTjALcoJZkBPMgpxgFuQEsyAnmAU5wSzICWbRHqIJfjxgjiz77T8hbd197bqGkwAAAABJRU5ErkJggg==
+      mediatype: image/png
+  customresourcedefinitions:
+    owned:
+      - name: minioinstances.miniocontroller.min.io
+        displayName: MinIOInstance
+        kind: MinIOInstance
+        version: v1beta1
+        description: Min IO Instance
+        resources:
+          - version: v1
+            kind: Namespace
+          - version: v1
+            kind: Deployment
+          - version: v1
+            kind: Service
+          - version: v1
+            kind: ReplicaSet
+          - version: v1
+            kind: Pod
+          - version: v1
+            kind: Secret
+          - version: v1
+            kind: ConfigMap
+          - version: v1
+            kind: ServiceAccount
+          - version: rbac.authorization.k8s.io/v1
+            kind: ClusterRoleBinding
+          - version: rbac.authorization.k8s.io/v1
+            kind: ClusterRole
+        specDescriptors:
+          - path: replicas
+            description: Replicas
+            displayName: Replicas
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+          - path: version
+            description: Version
+            displayName: Version
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:text'
+          - path: mountpath
+            description: Mountpath
+            displayName: Mountpath
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:text'
+          - path: subpath
+            description: Subpath
+            displayName: Subpath
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:text'
+        statusDescriptors: []
+    required: []
+  install:
+    strategy: deployment
+    spec:
+      clusterPermissions:
+        - serviceAccountName: minio-operator-sa
+          rules:
+          - apiGroups:
+              - ""
+            resources:
+              - secrets
+              - services
+            verbs:
+              - list
+              - watch
+              - get
+          - apiGroups:
+              - apps
+            resources:
+              - statefulsets
+            verbs:
+              - list
+              - watch
+              - get
+          - apiGroups:
+            - miniocontroller.min.io
+            resources:
+              - minioinstances
+            verbs:
+              - list
+              - watch
+              - get
+      permissions:
+        - serviceAccountName: minio-operator-sa
+          rules:
+            - apiGroups:
+              - ""
+              resources:
+                - namespaces
+                - secrets
+                - pods
+                - services
+                - events
+              verbs:
+                - get
+                - watch
+                - create
+                - list
+                - patch
+            - apiGroups:
+              - "apps"
+              resources:
+                - statefulsets
+              verbs:
+                - get
+                - create
+                - list
+                - patch
+                - watch
+            - apiGroups:
+              - "certificates.k8s.io"
+              resources:
+                - certificatesigningrequests
+                - certificatesigningrequests/approval
+                - certificatesigningrequests/status
+              verbs:
+                - update
+                - create
+                - get
+            - apiGroups:
+              - rbac.authorization.k8s.io
+              resources:
+                - roles
+                - rolebindings
+                - clusterroles
+                - clusterrolebindings
+              verbs:
+                - create
+                - delete
+            - apiGroups:
+              - "miniocontroller.min.io"
+              resources:
+                - '*'
+              verbs:
+                - '*'
+            - apiGroups:
+              - "min.io"
+              resources:
+                - '*'
+              verbs:
+                - '*'
+      deployments:
+        - name: minio-operator
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app: minio-operator
+            template:
+              metadata:
+                labels:
+                  app: minio-operator
+              spec:
+                serviceAccountName: minio-operator-sa
+                containers:
+                  - name: minio-operator
+                    image: 'minio/k8s-operator:1.0.3'
+  installModes:
+    - type: OwnNamespace
+      supported: true
+    - type: SingleNamespace
+      supported: true
+    - type: MultiNamespace
+      supported: true
+    - type: AllNamespaces
+      supported: false

--- a/olm-catalog/minio-operator/1.0.3/minioinstances.miniocontroller.min.io.crd.yaml
+++ b/olm-catalog/minio-operator/1.0.3/minioinstances.miniocontroller.min.io.crd.yaml
@@ -1,0 +1,30 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: minioinstances.miniocontroller.min.io
+spec:
+  group: miniocontroller.min.io
+  version: v1beta1
+  scope: Namespaced
+  names:
+    kind: MinIOInstance
+    singular: minioinstance
+    plural: minioinstances
+  preserveUnknownFields: true
+  validation:
+    openAPIV3Schema:
+      type: object
+      properties:
+        spec:
+          type: object
+          properties:
+            replicas:
+              type: integer
+              minimum: 1
+              maximum: 32
+            version:
+              type: string
+            mountpath:
+              type: string
+            subpath:
+              type: string

--- a/olm-catalog/minio-operator/minio-operator.package.yaml
+++ b/olm-catalog/minio-operator/minio-operator.package.yaml
@@ -1,0 +1,5 @@
+packageName: minio-operator
+channels:
+  - name: stable
+    currentCSV: minio-operator.v1.0.3
+defaultChannel: stable


### PR DESCRIPTION
It may be beneficial to track the olm catalog within the repository so that we can can have maintainers of the `minio-operator` to push changes to the `community-operators` repository.