### PR TITLE
Enable publishNotReadyAddresses for headless service

### DIFF
--- a/examples/minioinstance-with-external-service.yaml
+++ b/examples/minioinstance-with-external-service.yaml
@@ -24,7 +24,7 @@ apiVersion: miniocontroller.min.io/v1beta1
 kind: MinIOInstance
 metadata:
   name: minio
-## If specified, MinIOInstance pods will be dispatched by specified scheduler. 
+## If specified, MinIOInstance pods will be dispatched by specified scheduler.
 ## If not specified, the pod will be dispatched by default scheduler.
 # scheduler:
 #  name: my-custom-scheduler
@@ -47,8 +47,10 @@ spec:
   ## Note that the operator does not support upgrading from standalone to distributed mode.
   replicas: 4
   ## PodManagement policy for pods created by StatefulSet. Can be "OrderedReady" or "Parallel"
-  ## Refer https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#pod-management-policy 
+  ## Refer https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#pod-management-policy
   ## for details. Defaults to "Parallel"
+  ## If set to "OrderedReady", then disable Readiness checks below. Readiness check will only
+  ## work if PodManagementPolicy is set to "Parallel".
   podManagementPolicy: Parallel
   ## Enable Kubernetes based certificate generation and signing as explained in
   ## https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster
@@ -59,7 +61,14 @@ spec:
     commonName: ""
     organizationName: []
     dnsNames: []
-  ## Add environment variables to be set in MinIO container (https://github.com/minio/minio/tree/master/docs/config) 
+
+  ## Used to specify a toleration for a pod
+  # tolerations:
+  #  - effect: NoSchedule
+  #    key: dedicated
+  #    operator: Equal
+  #    value: storage
+  ## Add environment variables to be set in MinIO container (https://github.com/minio/minio/tree/master/docs/config)
   env:
     - name: MINIO_BROWSER
       value: "on"
@@ -82,13 +91,14 @@ spec:
   ## Readiness probe detects situations when MinIO server instance
   ## is not ready to accept traffic. Kubernetes doesn't forward
   ## traffic to the pod while readiness checks fail.
-  ## Recommended to be used only for standalone MinIO Instances. (replicas = 1)
-  # readiness:
-  #   httpGet:
-  #     path: /minio/health/ready
-  #     port: 9000
-  #   initialDelaySeconds: 120
-  #   periodSeconds: 20
+  ## Readiness check will only work if PodManagementPolicy is set to "Parallel".
+  ## Disable this check if you're setting PodManagementPolicy to "OrderedReady".
+  readiness:
+    httpGet:
+      path: /minio/health/ready
+      port: 9000
+    initialDelaySeconds: 120
+    periodSeconds: 20
   ## nodeSelector parameters for MinIO Pods. It specifies a map of key-value pairs. For the pod to be
   ## eligible to run on a node, the node must have each of the
   ## indicated key-value pairs as labels.

--- a/examples/minioinstance.yaml
+++ b/examples/minioinstance.yaml
@@ -36,6 +36,8 @@ spec:
   ## PodManagement policy for pods created by StatefulSet. Can be "OrderedReady" or "Parallel"
   ## Refer https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#pod-management-policy
   ## for details. Defaults to "Parallel"
+  ## If set to "OrderedReady", then disable Readiness checks below. Readiness check will only
+  ## work if PodManagementPolicy is set to "Parallel".
   podManagementPolicy: Parallel
   ## Enable Kubernetes based certificate generation and signing as explained in
   ## https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster
@@ -48,7 +50,7 @@ spec:
     dnsNames: []
 
   ## Used to specify a toleration for a pod
-  #tolerations:
+  # tolerations:
   #  - effect: NoSchedule
   #    key: dedicated
   #    operator: Equal
@@ -76,13 +78,14 @@ spec:
   ## Readiness probe detects situations when MinIO server instance
   ## is not ready to accept traffic. Kubernetes doesn't forward
   ## traffic to the pod while readiness checks fail.
-  ## Recommended to be used only for standalone MinIO Instances. (replicas = 1)
-  # readiness:
-  #   httpGet:
-  #     path: /minio/health/ready
-  #     port: 9000
-  #   initialDelaySeconds: 120
-  #   periodSeconds: 20
+  ## Readiness check will only work if PodManagementPolicy is set to "Parallel".
+  ## Disable this check if you're setting PodManagementPolicy to "OrderedReady".
+  readiness:
+    httpGet:
+      path: /minio/health/ready
+      port: 9000
+    initialDelaySeconds: 120
+    periodSeconds: 20
   ## nodeSelector parameters for MinIO Pods. It specifies a map of key-value pairs. For the pod to be
   ## eligible to run on a node, the node must have each of the
   ## indicated key-value pairs as labels.

--- a/pkg/resources/services/service.go
+++ b/pkg/resources/services/service.go
@@ -46,7 +46,8 @@ func NewForCluster(mi *miniov1beta1.MinIOInstance) *corev1.Service {
 			},
 		},
 		Spec: corev1.ServiceSpec{
-			Ports: []corev1.ServicePort{minioPort},
+			PublishNotReadyAddresses: true,
+			Ports:                    []corev1.ServicePort{minioPort},
 			Selector: map[string]string{
 				constants.InstanceLabel: mi.Name,
 			},


### PR DESCRIPTION
This will propagate SRV records for its Pods without respect
to their readiness for purpose of peer discovery.

Also updated the examples accordingly.