### PR TITLE
Remove empty replaces directive from CSV

### DIFF
--- a/olm-catalog/minio-operator/1.0.3/minio-operator.v1.0.3.clusterserviceversion.yaml
+++ b/olm-catalog/minio-operator/1.0.3/minio-operator.v1.0.3.clusterserviceversion.yaml
@@ -78,7 +78,6 @@ spec:
 
   maturity: stable
   version: 1.0.3
-  replaces: ''
   minKubeVersion: 1.14.0
   keywords:
     - Object Storage


### PR DESCRIPTION
Signed-off-by: Edmund Ochieng <ochienged@gmail.com>

Removing empty `replaces` directive tag in the CSV  as it apparently breaks automated tests. Can be added back in future when a new version is published.