### PR TITLE
update role verb

### DIFF
--- a/minio-operator.yaml
+++ b/minio-operator.yaml
@@ -70,6 +70,7 @@ rules:
   - list
   - patch
   - watch
+  - update
 - apiGroups:
   - "certificates.k8s.io"
   resources:


### PR DESCRIPTION
cluster role `minio-operator-role` need `update` permission, otherwise we will get an error when updating MinIOInstance: 
```
error syncing 'minio-operator-ns/minio': statefulsets.apps "minio" is forbidden: User "system:serviceaccount:minio-operator-ns:minio-operator-sa" cannot update resource "statefulsets" in API group "apps" in the namespace "minio-operator-ns"
```

Signed-off-by: zhuxiaoyang <sunzhu@yunify.com>