### PR TITLE
Make it possible to specify a custom clusterDomain

### DIFF
--- a/docs/operator-fields.md
+++ b/docs/operator-fields.md
@@ -21,6 +21,8 @@ MinIO Operator creates native Kubernetes resources within the cluster. If the Mi
 
 - `spec.metadata`: Define the object metadata to be passed to all the members pods of this MinIOInstance. This allows adding annotations and labels. For example,you can add Prometheus annotations here. Internally `metadata` is a struct type as [explained here](https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#ObjectMeta).
 
+- `spec.clusterDomain`: Set the internal Kubernetes cluster domain. If not specified, it falls back to the default value `cluster.local`.
+
 - `spec.image`: Set the container registry and image tag for MinIO server to be used in the MinIOInstance.
 
 - `spec.zones`: Set the number of servers per MinIO Zone. Add a new Zone field to expand the MinIO cluster. Read more on [MinIO zones here](https://github.com/minio/minio/blob/master/docs/distributed/DESIGN.md).

--- a/examples/minioinstance-with-external-service.yaml
+++ b/examples/minioinstance-with-external-service.yaml
@@ -40,6 +40,8 @@ spec:
       prometheus.io/path: /minio/prometheus/metrics
       prometheus.io/port: "9000"
       prometheus.io/scrape: "true"
+  ## Internal Kubernetes cluster domain. Defaults to cluster.local
+  #clusterDomain: cluster.local
   ## Registry location and Tag to download MinIO Server image
   image: minio/minio:RELEASE.2020-04-15T00-39-01Z
   zones:

--- a/examples/minioinstance.yaml
+++ b/examples/minioinstance.yaml
@@ -27,6 +27,8 @@ spec:
       prometheus.io/path: /minio/prometheus/metrics
       prometheus.io/port: "9000"
       prometheus.io/scrape: "true"
+  ## Internal Kubernetes cluster domain. Defaults to cluster.local
+  #clusterDomain: cluster.local
   ## Registry location and Tag to download MinIO Server image
   image: minio/minio:RELEASE.2020-04-15T00-39-01Z
   zones:

--- a/pkg/apis/miniocontroller/v1beta1/helper.go
+++ b/pkg/apis/miniocontroller/v1beta1/helper.go
@@ -87,6 +87,10 @@ func (mi *MinIOInstance) EnsureDefaults() *MinIOInstance {
 		mi.Spec.PodManagementPolicy = constants.DefaultPodManagementPolicy
 	}
 
+	if mi.Spec.ClusterDomain == "" {
+		mi.Spec.ClusterDomain = constants.DefaultClusterDomain
+	}
+
 	if mi.Spec.Image == "" {
 		mi.Spec.Image = constants.DefaultMinIOImage
 	}
@@ -141,7 +145,7 @@ func (mi *MinIOInstance) GetHosts() []string {
 	// append all the MinIOInstance replica URLs
 	// mi.Name is the headless service name
 	for i := 0; i < int(mi.Spec.Replicas); i++ {
-		hosts = append(hosts, fmt.Sprintf("%s-"+strconv.Itoa(i)+".%s.%s.svc.cluster.local", mi.Name, mi.GetHeadlessServiceName(), mi.Namespace))
+		hosts = append(hosts, fmt.Sprintf("%s-"+strconv.Itoa(i)+".%s.%s.svc.%s", mi.Name, mi.GetHeadlessServiceName(), mi.Namespace, mi.Spec.ClusterDomain))
 	}
 	return hosts
 }
@@ -150,7 +154,7 @@ func (mi *MinIOInstance) GetHosts() []string {
 // current MinIOInstance
 func (mi *MinIOInstance) GetWildCardName() string {
 	// mi.Name is the headless service name
-	return fmt.Sprintf("*.%s.%s.svc.cluster.local", mi.GetHeadlessServiceName(), mi.Namespace)
+	return fmt.Sprintf("*.%s.%s.svc.%s", mi.GetHeadlessServiceName(), mi.Namespace, mi.Spec.ClusterDomain)
 }
 
 // GetTLSSecretName returns the name of Secret that has TLS related Info (Cert & Prviate Key)

--- a/pkg/apis/miniocontroller/v1beta1/helper_test.go
+++ b/pkg/apis/miniocontroller/v1beta1/helper_test.go
@@ -14,6 +14,7 @@ func TestEnsureDefaults(t *testing.T) {
 
 	t.Run("defaults", func(t *testing.T) {
 		assert.Equal(t, mi.Spec.Replicas, int32(constants.DefaultReplicas))
+		assert.Equal(t, mi.Spec.ClusterDomain, constants.DefaultClusterDomain)
 		assert.Equal(t, mi.Spec.Image, constants.DefaultMinIOImage)
 		assert.Equal(t, mi.Spec.Mountpath, constants.MinIOVolumeMountPath)
 		assert.Equal(t, mi.Spec.Subpath, constants.MinIOVolumeSubPath)
@@ -37,13 +38,16 @@ func TestEnsureDefaults(t *testing.T) {
 	})
 
 	t.Run("defaults don't override", func(t *testing.T) {
+		newClusterDomain := "k8s.example.com"
 		newImage := "minio/minio:latest"
 		newReplicas := int32(99)
+		mi.Spec.ClusterDomain = newClusterDomain
 		mi.Spec.Image = newImage
 		mi.Spec.Replicas = newReplicas
 
 		mi.EnsureDefaults()
 
+		assert.Equal(t, newClusterDomain, mi.Spec.ClusterDomain)
 		assert.Equal(t, newImage, mi.Spec.Image)
 		assert.Equal(t, newReplicas, mi.Spec.Replicas)
 	})

--- a/pkg/apis/miniocontroller/v1beta1/types.go
+++ b/pkg/apis/miniocontroller/v1beta1/types.go
@@ -56,6 +56,9 @@ type LocalCertificateReference struct {
 
 // MinIOInstanceSpec is the spec for a MinIOInstance resource
 type MinIOInstanceSpec struct {
+	// ClusterDomain specifies the internal Kubernetes cluster domain
+	// +optional
+	ClusterDomain string `json:"clusterDomain,omitempty"`
 	// Image defines the MinIOInstance Docker image.
 	// +optional
 	Image string `json:"image,omitempty"`

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -66,6 +66,9 @@ const DefaultPodManagementPolicy = appsv1.ParallelPodManagement
 // https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
 const DefaultUpdateStrategy = "RollingUpdate"
 
+// DefaultClusterDomain specifies the default cluster domain if not specified otherwise
+const DefaultClusterDomain = "cluster.local"
+
 // HeadlessServiceNameSuffix specifies the suffix added to MinIOInstance name to create a headless service
 const HeadlessServiceNameSuffix = "-hl-svc"
 


### PR DESCRIPTION
…  if it differs from the default `cluster.local`.

A new field `clusterDomain` is added and if not specified, it falls back to the default of `cluster.local`.

Note that if you modify a `MinIOInstance`, the `StatefulSet` resource is _not_ modified currently in this commit.
So it's only taken into account when creating a `MinIOInstance`.

This should help for issue #70 and issue minio/minio#6775.

NB: I tested it by building a new image and deploying it to my own k8s-cluster (both specifying the `clusterDomain` property and leaving it out).

Lastly, I'm not that familiar in Go, so I tried until it worked 😄 let me know if there are other things that need to be modified or taken into account

This is the yaml I tried:
```yaml
apiVersion: miniocontroller.min.io/v1beta1
kind: MinIOInstance
metadata:
  name: minio
spec:
  clusterDomain: custom.domain.example.com <--
  selector:
    matchLabels:
      app: minio # Should match spec.metadata.labels
  ## Add metadata to the all pods created by the StatefulSet
  metadata:
    labels:
      app: minio # Should match spec.selector.matchLabels
    annotations:
      prometheus.io/path: /minio/prometheus/metrics
      prometheus.io/port: "9000"
      prometheus.io/scrape: "true"
  ## Registry location and Tag to download MinIO Server image
  image: minio/minio:RELEASE.2020-01-03T19-12-21Z
  ...
```