### PR TITLE
Give the Service port a name so that Istio selects the correct protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,16 @@ kubectl patch minioinstances.miniocontroller.min.io minio --patch "$(cat example
 
 You can further keep adding new zones in the `patch.yaml` file and apply the patch, to add new nodes to existing cluster. 
 
+### Expose MinIO via Istio
+
+Istio >= 1.4 has support for headless Services, so instead of creating an explicit `Service` for the created MinIO instance, you can also directly target the headless Service that is created by the operator.
+
+For example, to expose the created headless Service `minio-hl-svc` on http://minio.example.com:
+
+```
+kubectl apply -f https://raw.githubusercontent.com/minio/minio-operator/master/examples/expose-via-istio.yaml
+```
+
 ## Features
 
 MinIO-Operator currently supports following features:

--- a/examples/expose-via-istio.yaml
+++ b/examples/expose-via-istio.yaml
@@ -1,0 +1,30 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: minio
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+    - port:
+        number: 80
+        name: http-minio
+        protocol: HTTP
+      hosts:
+        - "minio.example.com"
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: minio
+spec:
+  hosts:
+  - "minio.example.com"
+  gateways:
+  - minio
+  http:
+  - route:
+    - destination:
+        host: minio-hl-svc
+        port:
+          number: 9000

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -35,6 +35,9 @@ const MinIOOperatorVersionLabel = "v1beta1.min.io/version"
 // MinIOPort specifies the default MinIOInstance port number.
 const MinIOPort = 9000
 
+// MinIOServicePortName specifies the default Service's port name, e.g. for automatic protocol selection in Istio
+const MinIOServicePortName = "http-minio"
+
 // MinIOVolumeName specifies the default volume name for MinIO volumes
 const MinIOVolumeName = "export"
 

--- a/pkg/resources/services/service.go
+++ b/pkg/resources/services/service.go
@@ -28,7 +28,7 @@ import (
 
 // NewForCluster will return a new headless Kubernetes service for a MinIOInstance
 func NewForCluster(mi *miniov1beta1.MinIOInstance) *corev1.Service {
-	minioPort := corev1.ServicePort{Port: constants.MinIOPort}
+	minioPort := corev1.ServicePort{Port: constants.MinIOPort, Name: constants.MinIOServicePortName}
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels:    map[string]string{constants.InstanceLabel: mi.Name},


### PR DESCRIPTION
In this case MinIO exposes regular HTTP, so name it "http-minio".

See https://istio.io/docs/ops/configuration/traffic-management/protocol-selection/

This way I can make an Istio `Gateway` and `VirtualService` that point towards the created `minio-hl-svc` `Service` and expose it through my own https endpoint.

Otherwise, Istio falls back to protocol detection and modern browser try HTTP/2 which doesn't work.