### PR TITLE
Remove fixed namespace from install

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,18 +24,25 @@ MinIO-Operator brings native MinIO, [MCS](https://github.com/minio/mcs), [KES](h
 
 To start MinIO-Operator, use the `minio-operator.yaml` file.
 
-```
-kubectl create -f https://raw.githubusercontent.com/minio/minio-operator/master/minio-operator.yaml
+```bash
+kubectl apply -f https://raw.githubusercontent.com/minio/minio-operator/master/minio-operator.yaml
 ```
 
 This will create all relevant resources required for the Operator to work.
+
+You could install the MinIO Operator a custom namespace by passing the `-n` flag
+
+```bash
+kubectl create namespace minio-operator-ns
+kubectl apply -n minio-operator-ns -f https://raw.githubusercontent.com/minio/minio-operator/master/minio-operator.yaml
+```
 
 ### Create a MinIO instance
 
 Once MinIO-Operator deployment is running, you can create MinIO instances using the below command
 
 ```
-kubectl create -f https://raw.githubusercontent.com/minio/minio-operator/master/examples/minioinstance.yaml
+kubectl apply -f https://raw.githubusercontent.com/minio/minio-operator/master/examples/minioinstance.yaml
 ```
 
 ### Expand a MinIO cluster

--- a/minio-operator.yaml
+++ b/minio-operator.yaml
@@ -1,8 +1,3 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: minio-operator-ns
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -138,13 +133,11 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: minio-operator-sa
-  namespace: minio-operator-ns
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: minio-operator-binding
-  namespace: minio-operator-ns
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -152,13 +145,11 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: minio-operator-sa
-  namespace: minio-operator-ns
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: minio-operator
-  namespace: minio-operator-ns
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
Removing the hardcoded namespace `minio-operator-ns` from the `minio-operator.yaml` install file.

This is to allow the user installing the operator to choose his own namespace via CLI

```bash
kubectl apply -n my-namespace -f minio-instance.yaml
```