### PR TITLE
Fix default namespace for install and add kustomize

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,10 @@ kubectl apply -f https://raw.githubusercontent.com/minio/minio-operator/master/m
 
 This will create all relevant resources required for the Operator to work.
 
-You could install the MinIO Operator a custom namespace by passing the `-n` flag
+You could install the MinIO Operator a custom namespace by customizing the `minio-operator.yaml` file or using [kustomize](https://github.com/kubernetes-sigs/kustomize) 
 
 ```bash
-kubectl create namespace minio-operator-ns
-kubectl apply -n minio-operator-ns -f https://raw.githubusercontent.com/minio/minio-operator/master/minio-operator.yaml
+kustomize build | kubectl apply -f -
 ```
 
 ### Create a MinIO instance

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -1,0 +1,4 @@
+namespace: minio-operator-ns
+
+resources:
+  - minio-operator.yaml

--- a/minio-operator.yaml
+++ b/minio-operator.yaml
@@ -133,6 +133,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: minio-operator-sa
+  namespace: default
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -145,11 +146,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: minio-operator-sa
+  namespace: default
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: minio-operator
+  namespace: default
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
Fixes the default namespace for non `namespaced` resources in the install file `minio-operator.yaml` and adds a `kustomization.yaml` to use with the official [kustomize](https://github.com/kubernetes-sigs/kustomize) tool so people can change the namespace of the install file at will.

Fixes #112 