### PR TITLE
Add flag for go template to format host names

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ MinIO-Operator brings native MinIO, [MCS](https://github.com/minio/mcs), [KES](h
 | Create and delete highly available distributed MinIO clusters  | [Create a MinIO Instance](https://github.com/minio/minio-operator#create-a-minio-instance). |
 | Automatic TLS for MinIO                                        | [Automatic TLS for MinIO Instance](https://github.com/minio/minio-operator/blob/master/docs/tls.md#automatic-csr-generation). |
 | Expand an existing MinIO cluster                               | [Expand a MinIO Cluster](https://github.com/minio/minio-operator/blob/master/docs/adding-zones.md). |
+| Use a custom template for hostname discovery                   | [Custom Hostname Discovery](https://github.com/minio/minio-operator/blob/master/docs/custom-name-templates.md). |
 | Deploy MCS with MinIO cluster  | [Deploy MinIO Instance with MCS](https://github.com/minio/minio-operator/blob/master/docs/mcs.md). |
 | Deploy KES with MinIO cluster  | [Deploy MinIO Instance with KES](https://github.com/minio/minio-operator/blob/master/docs/kes.md). |
 | Deploy mc mirror  | [Deploy Mirror Instance](https://github.com/minio/minio-operator/blob/master/docs/mirror.md). |

--- a/docs/custom-name-templates.md
+++ b/docs/custom-name-templates.md
@@ -1,0 +1,29 @@
+# Custom Hostname Discovery
+
+[![Slack](https://slack.min.io/slack?type=svg)](https://slack.min.io)
+[![Docker Pulls](https://img.shields.io/docker/pulls/minio/k8s-operator.svg?maxAge=604800)](https://hub.docker.com/r/minio/k8s-operator)
+
+This document explains how to control the names used for host discovery.  This allows us to discover hosts using external name services, which is useful for serving with trusted certificates.
+
+## Getting Started
+
+Assuming you have a MinIO cluster with single zone, `zone-0` with 4 drives (as shown in [examples](https://github.com/minio/minio-operator/tree/master/examples)). You can dd a new zone `zone-1` with 4 drives using `kubectl patch` command.
+
+The example cluster is named minio, so the four servers will be called `minio-0`, `minio-1`, `minio-2`, and `minio-3`.  If all of your hosts are available at the domain `example.com` then you can use the `--hosts-template` flag to update discovery:
+
+```
+  containers:
+  - command:
+    - /minio-operator
+    - --hosts-template
+    - '{{.StatefulSet}}-{{.Ellipsis}}.example.com'
+```
+
+This will generate the discovery string `minio-{0...3}.example.com`.  The following fields are available
+| Field                 | Description |
+|-----------------------|-------------|
+| StatefulSet | The name of the instance StatefulSet (e.g. `minio`). |
+| CIService | The name of the service provided in `spec.serviceName`. |
+| HLService | The name of the headless service that is generated (e.g. `minio-hl-service`) |
+| Ellipsis | `{0...N-1}` the per-zone host numbers. |
+| Domain | The cluster domain, either `cluster.local` or the contents of the `CLUSTER_DOMAIN` environment variable. |

--- a/main.go
+++ b/main.go
@@ -45,9 +45,10 @@ import (
 var Version = "DEVELOPMENT.GOGET"
 
 var (
-	masterURL    string
-	kubeconfig   string
-	checkVersion bool
+	masterURL     string
+	kubeconfig    string
+	hostsTemplate string
+	checkVersion  bool
 
 	onlyOneSignalHandler = make(chan struct{})
 	shutdownSignals      = []os.Signal{os.Interrupt, syscall.SIGTERM}
@@ -56,6 +57,7 @@ var (
 func init() {
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "path to a kubeconfig. Only required if out-of-cluster")
 	flag.StringVar(&masterURL, "master", "", "the address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster")
+	flag.StringVar(&hostsTemplate, "hosts-template", "", "the go template to use for hostname formatting of name fields (StatefulSet, CIService, HLService, Ellipsis, Domain)")
 	flag.BoolVar(&checkVersion, "version", false, "print version")
 }
 
@@ -117,7 +119,8 @@ func main() {
 		kubeInformerFactory.Apps().V1().Deployments(),
 		kubeInformerFactory.Batch().V1().Jobs(),
 		minioInformerFactory.Operator().V1().MinIOInstances(),
-		kubeInformerFactory.Core().V1().Services())
+		kubeInformerFactory.Core().V1().Services(),
+		hostsTemplate)
 
 	mirrorController := mirror.NewController(kubeClient, controllerClient,
 		kubeInformerFactory.Batch().V1().Jobs(),

--- a/pkg/apis/operator.min.io/v1/helper_test.go
+++ b/pkg/apis/operator.min.io/v1/helper_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestEnsureDefaults(t *testing.T) {
@@ -40,5 +41,41 @@ func TestEnsureDefaults(t *testing.T) {
 		mi.EnsureDefaults()
 
 		assert.Equal(t, newImage, mi.Spec.Image)
+	})
+}
+
+func TestTemplateVariables(t *testing.T) {
+	servers := 2
+	mi := MinIOInstance{
+		ObjectMeta: metav1.ObjectMeta{Name: "test"},
+		Spec: MinIOInstanceSpec{
+			Zones: []Zone{{"single", int32(servers)}},
+		},
+	}
+	mi.EnsureDefaults()
+
+	t.Run("StatefulSet", func(t *testing.T) {
+		hosts := mi.TemplatedMinIOHosts("{{.StatefulSet}}")
+		assert.Contains(t, hosts, mi.MinIOStatefulSetName())
+	})
+
+	t.Run("CIService", func(t *testing.T) {
+		hosts := mi.TemplatedMinIOHosts("{{.CIService}}")
+		assert.Contains(t, hosts, mi.MinIOCIServiceName())
+	})
+
+	t.Run("HLService", func(t *testing.T) {
+		hosts := mi.TemplatedMinIOHosts("{{.HLService}}")
+		assert.Contains(t, hosts, mi.MinIOHLServiceName())
+	})
+
+	t.Run("Ellipsis", func(t *testing.T) {
+		hosts := mi.TemplatedMinIOHosts("{{.Ellipsis}}")
+		assert.Contains(t, hosts, ellipsis(0, servers-1))
+	})
+
+	t.Run("Domain", func(t *testing.T) {
+		hosts := mi.TemplatedMinIOHosts("{{.Domain}}")
+		assert.Contains(t, hosts, ClusterDomain)
 	})
 }

--- a/pkg/controller/cluster/kes-csr.go
+++ b/pkg/controller/cluster/kes-csr.go
@@ -101,7 +101,7 @@ func (c *Controller) createKESTLSCSR(ctx context.Context, mi *miniov1.MinIOInsta
 // createMinIOClientTLSCSR handles all the steps required to create the CSR: from creation of keys, submitting CSR and
 // finally creating a secret that KES Statefulset will use for MinIO Client Auth
 func (c *Controller) createMinIOClientTLSCSR(ctx context.Context, mi *miniov1.MinIOInstance) error {
-	privKeysBytes, csrBytes, err := generateCryptoData(mi)
+	privKeysBytes, csrBytes, err := generateCryptoData(mi, c.hostsTemplate)
 	if err != nil {
 		klog.Errorf("Private Key and CSR generation failed with error: %v", err)
 		return err


### PR DESCRIPTION
When using an alternate DNS like external-dns, your host names will be
different than the internal core-dns format.  This adds a flag so that
the user can specify the name format using a go template.