### PR TITLE
Fixing multiple issues

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go-version: [1.14.x]
+        go-version: [1.13.x]
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2

--- a/docs/kes.md
+++ b/docs/kes.md
@@ -24,9 +24,8 @@ KES Configuration is a part of MinIOInstance yaml file. Check the sample file [a
 | spec.kes | Defines the KES configuration. Refer [this](https://github.com/minio/kes) |
 | spec.kes.replicas | Number of KES pods to be created. |
 | spec.kes.image | Defines the KES image. |
-| spec.kes.configSecret | Secret to specify KES Configuration. This is a mandatory field. |
-| spec.kes.selector | Add a selector for the KES. Which will be used by the KES pods for grouping. (Note: Should not match the labels provided in `spec.selector`) |
-| spec.kes.metadata | This allows a way to map metadata to the KES pods. Internally `metadata` is a struct type as [explained here](https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#ObjectMeta). [Note: Should match the labels in `spec.kes.selector`] |
+| spec.kes.kesSecret | Secret to specify KES Configuration. This is a mandatory field. |
+| spec.kes.metadata | This allows a way to map metadata to the KES pods. Internally `metadata` is a struct type as [explained here](https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#ObjectMeta). |
 
 ### Create MinIO Instance
 

--- a/docs/mcs.md
+++ b/docs/mcs.md
@@ -23,8 +23,7 @@ MCS Configuration is a part of MinIOInstance yaml file. Check the sample file [a
 | spec.mcs.image | Defines the mcs image |
 | spec.mcs.replicas | Number of MCS pods to be created. |
 | spec.mcs.mcsSecret | Use this secret to assign mcs credentials to MinIOInstance. |
-| spec.mcs.selector | Add a selector for the mcs. Which will be used by the mcs container for grouping. (Note: Should not match the labels provided in `spec.selector`) |
-| spec.mcs.metadata | This allows a way to map metadata to the mcs container. Internally `metadata` is a struct type as [explained here](https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#ObjectMeta). [Note: Should match the labels in `spec.mcs.selector`] |
+| spec.mcs.metadata | This allows a way to map metadata to the mcs container. Internally `metadata` is a struct type as [explained here](https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#ObjectMeta). |
 
 ### Create MinIO Instance
 

--- a/docs/operator-fields.md
+++ b/docs/operator-fields.md
@@ -48,14 +48,12 @@ If the MirrorInstance is named as `mirrorinstance`, resources and their names as
 | spec.mcs.image | Defines the mcs image. |
 | spec.mcs.replicas | Number of MCS pods to be created. |
 | spec.mcs.mcsSecret | Use this secret to assign mcs credentials to MinIOInstance. |
-| spec.mcs.selector | Add a selector for the mcs. Which will be used by the mcs container for grouping. (Note: Should not match the labels provided in `spec.selector`) |
-| spec.mcs.metadata | This allows a way to map metadata to the mcs container. Internally `metadata` is a struct type as [explained here](https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#ObjectMeta). [Note: Should match the labels in `spec.mcs.selector`] |
+| spec.mcs.metadata | This allows a way to map metadata to the mcs container. Internally `metadata` is a struct type as [explained here](https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#ObjectMeta). |
 | spec.kes | Defines the KES configuration. Refer [this](https://github.com/minio/kes) |
 | spec.kes.replicas | Number of KES pods to be created. |
 | spec.kes.image | Defines the KES image. |
-| spec.kes.configSecret | Secret to specify KES Configuration. This is a mandatory field. |
-| spec.kes.selector | Add a selector for the KES. Which will be used by the KES pods for grouping. (Note: Should not match the labels provided in `spec.selector`) |
-| spec.kes.metadata | This allows a way to map metadata to the KES pods. Internally `metadata` is a struct type as [explained here](https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#ObjectMeta). [Note: Should match the labels in `spec.kes.selector`] |
+| spec.kes.kesSecret | Secret to specify KES Configuration. This is a mandatory field. |
+| spec.kes.metadata | This allows a way to map metadata to the KES pods. Internally `metadata` is a struct type as [explained here](https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#ObjectMeta). |
 
 ## MirrorInstance Fields
 

--- a/examples/minioinstance-kes.yaml
+++ b/examples/minioinstance-kes.yaml
@@ -10,7 +10,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: minio-mcs-secret
+  name: mcs-secret
 type: Opaque
 data:
   MCS_HMAC_JWT_SECRET: WU9VUkpXVFNJR05JTkdTRUNSRVQ= # base 64 encoded "YOURJWTSIGNINGSECRET" (echo -n 'YOURJWTSIGNINGSECRET' | base64)
@@ -44,19 +44,16 @@ metadata:
 # scheduler:
 #  name: my-custom-scheduler
 spec:
-  selector:
-    matchLabels:
-      app: minio # Should match spec.metadata.labels
   ## Add metadata to the all pods created by the StatefulSet
   metadata:
     labels:
-      app: minio # Should match spec.selector.matchLabels
+      app: minio
     annotations:
       prometheus.io/path: /minio/prometheus/metrics
       prometheus.io/port: "9000"
       prometheus.io/scrape: "true"
   ## Registry location and Tag to download MinIO Server image
-  image: minio/minio:RELEASE.2020-05-08T02-40-49Z
+  image: minio/minio:RELEASE.2020-06-03T22-13-49Z
   ## A ClusterIP Service will be created with the given name
   serviceName: minio-internal-service
   ## Secret with credentials to be used by MinIO instance.
@@ -88,28 +85,22 @@ spec:
           storage: 1Ti
   ## Define configuration for MCS (Graphical user interface for MinIO)
   mcs:
-    image: minio/mcs:v0.0.4
+    image: minio/mcs:v0.0.6
     replicas: 2
     mcsSecret:
-      name: minio-mcs-secret
+      name: mcs-secret
     metadata:
       labels:
-        app: mcs # Should match spec.mcs.selector.matchLabels
-    selector:
-      matchLabels:
-        app: mcs # Should match spec.mcs.metadata.labels
+        app: mcs
   ## Define configuration for KES (stateless and distributed key-management system)
   kes:
     image: minio/kes:v0.9.0
     replicas: 2
-    configSecret:
+    kesSecret:
       name: kes-config
     metadata:
       labels:
-        app: kes # Should match spec.kes.selector.matchLabels
-    selector:
-      matchLabels:
-        app: kes # Should match spec.kes.metadata.labels
+        app: kes
   ## Secret with certificates to configure TLS for MinIO certs. Create secrets as explained
   ## here: https://github.com/minio/minio/tree/master/docs/tls/kubernetes#2-create-kubernetes-secret
   # externalCertSecret:

--- a/examples/minioinstance-mcs.yaml
+++ b/examples/minioinstance-mcs.yaml
@@ -10,7 +10,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: minio-mcs-secret
+  name: mcs-secret
 type: Opaque
 data:
   MCS_HMAC_JWT_SECRET: WU9VUkpXVFNJR05JTkdTRUNSRVQ= # base 64 encoded "YOURJWTSIGNINGSECRET" (echo -n 'YOURJWTSIGNINGSECRET' | base64)
@@ -44,19 +44,16 @@ metadata:
 # scheduler:
 #  name: my-custom-scheduler
 spec:
-  selector:
-    matchLabels:
-      app: minio # Should match spec.metadata.labels
   ## Add metadata to the all pods created by the StatefulSet
   metadata:
     labels:
-      app: minio # Should match spec.selector.matchLabels
+      app: minio
     annotations:
       prometheus.io/path: /minio/prometheus/metrics
       prometheus.io/port: "9000"
       prometheus.io/scrape: "true"
   ## Registry location and Tag to download MinIO Server image
-  image: minio/minio:RELEASE.2020-05-08T02-40-49Z
+  image: minio/minio:RELEASE.2020-06-03T22-13-49Z
   ## A ClusterIP Service will be created with the given name
   serviceName: minio-internal-service
   ## Secret with credentials to be used by MinIO instance.
@@ -88,16 +85,13 @@ spec:
           storage: 1Ti
   ## Define configuration for MCS (Graphical user interface for MinIO)
   mcs:
-    image: minio/mcs:v0.0.4
+    image: minio/mcs:v0.0.6
     replicas: 2
     mcsSecret:
-      name: minio-mcs-secret
+      name: mcs-secret
     metadata:
       labels:
-        app: mcs # Should match spec.mcs.selector.matchLabels
-    selector:
-      matchLabels:
-        app: mcs # Should match spec.mcs.metadata.labels
+        app: mcs
   ## Secret with certificates to configure TLS for MinIO certs. Create secrets as explained
   ## here: https://github.com/minio/minio/tree/master/docs/tls/kubernetes#2-create-kubernetes-secret
   # externalCertSecret:

--- a/examples/minioinstance.yaml
+++ b/examples/minioinstance.yaml
@@ -42,7 +42,7 @@ spec:
       prometheus.io/port: "9000"
       prometheus.io/scrape: "true"
   ## Registry location and Tag to download MinIO Server image
-  image: minio/minio:RELEASE.2020-05-08T02-40-49Z
+  image: minio/minio:RELEASE.2020-06-03T22-13-49Z
   ## A ClusterIP Service will be created with the given name
   serviceName: minio-internal-service
   zones:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/minio/minio-operator
 
-go 1.14
+go 1.13
 
 require (
 	github.com/evanphx/json-patch v4.5.0+incompatible // indirect

--- a/minio-operator.yaml
+++ b/minio-operator.yaml
@@ -51,6 +51,7 @@ spec:
                   type: string
                 mcs:
                   type: object
+                  x-kubernetes-preserve-unknown-fields: true
                   properties:
                     image:
                       type: string
@@ -58,6 +59,20 @@ spec:
                       type: integer
                       default: 2
                     mcsSecret:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                kes:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                  properties:
+                    image:
+                      type: string
+                    replicas:
+                      type: integer
+                      default: 2
+                    kesSecret:
                       type: object
                       properties:
                         name:
@@ -116,7 +131,7 @@ rules:
   - watch
   - create
   - list
-  - patch
+  - delete
 - apiGroups:
   - apps
   resources:
@@ -152,6 +167,7 @@ rules:
   - update
   - create
   - get
+  - delete
 - apiGroups:
   - operator.min.io
   resources:

--- a/pkg/apis/operator.min.io/v1/constants.go
+++ b/pkg/apis/operator.min.io/v1/constants.go
@@ -67,7 +67,7 @@ const MinIOVolumeMountPath = "/export"
 const MinIOVolumeSubPath = ""
 
 // DefaultMinIOImage specifies the default MinIO Docker hub image
-const DefaultMinIOImage = "minio/minio:RELEASE.2020-05-08T02-40-49Z"
+const DefaultMinIOImage = "minio/minio:RELEASE.2020-06-03T22-13-49Z"
 
 // DefaultMinIOAccessKey specifies default access key for MinIOInstance
 const DefaultMinIOAccessKey = "AKIAIOSFODNN7EXAMPLE"
@@ -122,7 +122,7 @@ const MirrorCRDResourceKind = "MirrorInstance"
 // MCS Related Constants
 
 // DefaultMCSImage specifies the latest MCS Docker hub image
-const DefaultMCSImage = "minio/mcs:v0.0.4"
+const DefaultMCSImage = "minio/mcs:v0.0.6"
 
 // MCSInstanceLabel is applied to the MCS pods of a MinIOInstance cluster
 const MCSInstanceLabel = "v1.min.io/mcs"

--- a/pkg/apis/operator.min.io/v1/helper.go
+++ b/pkg/apis/operator.min.io/v1/helper.go
@@ -51,12 +51,6 @@ func (mi *MinIOInstance) HasMetadata() bool {
 	return mi.Spec.Metadata != nil
 }
 
-// HasSelector returns true if the user has provided a pod selector
-// field (ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-selector)
-func (mi *MinIOInstance) HasSelector() bool {
-	return mi.Spec.Selector != nil
-}
-
 // HasCertConfig returns true if the user has provided a certificate
 // config
 func (mi *MinIOInstance) HasCertConfig() bool {
@@ -160,12 +154,6 @@ func (mi *MinIOInstance) EnsureDefaults() *MinIOInstance {
 				DNSNames:         mi.MinIOHosts(),
 				OrganizationName: DefaultOrgName,
 			}
-		}
-	}
-
-	if !mi.HasSelector() {
-		mi.Spec.Selector = &metav1.LabelSelector{
-			MatchLabels: mi.MinIOPodLabels(),
 		}
 	}
 
@@ -296,22 +284,10 @@ func (mi *MinIOInstance) HasMCSMetadata() bool {
 	return mi.Spec.MCS != nil && mi.Spec.MCS.Metadata != nil
 }
 
-// HasMCSSelector returns true if the user has provided a mcs selector
-// for a MinIOInstance else false
-func (mi *MinIOInstance) HasMCSSelector() bool {
-	return mi.Spec.MCS != nil && mi.Spec.MCS.Selector != nil
-}
-
 // HasKESMetadata returns true if the user has provided KES metadata
 // for a MinIOInstance else false
 func (mi *MinIOInstance) HasKESMetadata() bool {
 	return mi.Spec.KES != nil && mi.Spec.KES.Metadata != nil
-}
-
-// HasKESSelector returns true if the user has provided a KES selector
-// for a MinIOInstance else false
-func (mi *MinIOInstance) HasKESSelector() bool {
-	return mi.Spec.KES != nil && mi.Spec.KES.Selector != nil
 }
 
 // CreateMCSUser function creates an admin user

--- a/pkg/apis/operator.min.io/v1/types.go
+++ b/pkg/apis/operator.min.io/v1/types.go
@@ -78,9 +78,6 @@ type MinIOInstanceSpec struct {
 	// VolumeClaimTemplate allows a user to specify how volumes inside a MinIOInstance
 	// +optional
 	VolumeClaimTemplate *corev1.PersistentVolumeClaim `json:"volumeClaimTemplate,omitempty"`
-	// Selector is a label query over pods that should match the replica count.
-	// +optional
-	Selector *metav1.LabelSelector `json:"selector,omitempty"`
 	// NodeSelector is a selector which must be true for the pod to fit on a node.
 	// Selector which must match a node's labels for the pod to be scheduled on that node.
 	// More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
@@ -169,7 +166,7 @@ type Readiness struct {
 	PeriodSeconds       int32 `json:"periodSeconds"`
 }
 
-// MCSConfig defines the credentials for mcs
+// MCSConfig defines the specifications for MCS Deployment
 type MCSConfig struct {
 	// Replicas defines number of pods for KES StatefulSet.
 	// +optional
@@ -179,8 +176,7 @@ type MCSConfig struct {
 	Image string `json:"image,omitempty"`
 	// This secret provides all environment variables for KES
 	// This is a mandatory field
-	MCSSecret *corev1.LocalObjectReference `json:"mcsSecret,omitempty"`
-	Selector  *metav1.LabelSelector        `json:"selector,omitempty"`
+	MCSSecret *corev1.LocalObjectReference `json:"mcsSecret"`
 	Metadata  *metav1.ObjectMeta           `json:"metadata,omitempty"`
 }
 
@@ -192,10 +188,9 @@ type KESConfig struct {
 	// Image defines the MinIOInstance Docker image.
 	// +optional
 	Image string `json:"image,omitempty"`
-	// This configSecret serves as the configuration for KES
+	// This kesSecret serves as the configuration for KES
 	// This is a mandatory field
-	Configuration *corev1.LocalObjectReference `json:"configSecret"`
-	Selector      *metav1.LabelSelector        `json:"selector,omitempty"`
+	Configuration *corev1.LocalObjectReference `json:"kesSecret"`
 	Metadata      *metav1.ObjectMeta           `json:"metadata,omitempty"`
 }
 

--- a/pkg/apis/operator.min.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/operator.min.io/v1/zz_generated.deepcopy.go
@@ -81,11 +81,6 @@ func (in *KESConfig) DeepCopyInto(out *KESConfig) {
 		*out = new(corev1.LocalObjectReference)
 		**out = **in
 	}
-	if in.Selector != nil {
-		in, out := &in.Selector, &out.Selector
-		*out = new(metav1.LabelSelector)
-		(*in).DeepCopyInto(*out)
-	}
 	if in.Metadata != nil {
 		in, out := &in.Metadata, &out.Metadata
 		*out = new(metav1.ObjectMeta)
@@ -143,11 +138,6 @@ func (in *MCSConfig) DeepCopyInto(out *MCSConfig) {
 		in, out := &in.MCSSecret, &out.MCSSecret
 		*out = new(corev1.LocalObjectReference)
 		**out = **in
-	}
-	if in.Selector != nil {
-		in, out := &in.Selector, &out.Selector
-		*out = new(metav1.LabelSelector)
-		(*in).DeepCopyInto(*out)
 	}
 	if in.Metadata != nil {
 		in, out := &in.Metadata, &out.Metadata
@@ -270,11 +260,6 @@ func (in *MinIOInstanceSpec) DeepCopyInto(out *MinIOInstanceSpec) {
 	if in.VolumeClaimTemplate != nil {
 		in, out := &in.VolumeClaimTemplate, &out.VolumeClaimTemplate
 		*out = new(corev1.PersistentVolumeClaim)
-		(*in).DeepCopyInto(*out)
-	}
-	if in.Selector != nil {
-		in, out := &in.Selector, &out.Selector
-		*out = new(metav1.LabelSelector)
 		(*in).DeepCopyInto(*out)
 	}
 	if in.NodeSelector != nil {

--- a/pkg/resources/jobs/kes-job.go
+++ b/pkg/resources/jobs/kes-job.go
@@ -116,21 +116,15 @@ func kesEnvironmentVars(mi *miniov1.MinIOInstance) []corev1.EnvVar {
 // metadata.
 func kesMetadata(mi *miniov1.MinIOInstance) metav1.ObjectMeta {
 	meta := metav1.ObjectMeta{}
-
 	if mi.HasKESMetadata() {
 		meta = *mi.Spec.KES.Metadata
 	}
-
+	if meta.Labels == nil {
+		meta.Labels = make(map[string]string)
+	}
 	// Add the additional label from spec
 	for k, v := range mi.KESPodLabels() {
 		meta.Labels[k] = v
-	}
-
-	// Add the Selector labels set by user
-	if mi.HasKESSelector() {
-		for k, v := range mi.Spec.KES.Selector.MatchLabels {
-			meta.Labels[k] = v
-		}
 	}
 	return meta
 }


### PR DESCRIPTION
- Remove the usage of Selector in minio, kes & mcs. Selector is
supposed to be used internally for filtering pods, so there is no
need to use selectors.

- Update docker image tags for minio, kes & mcs.

- Add access privileges as required for certificates and secrets.

- Use go 1.13 till https://github.com/golang/go/issues/37369 is
addressed.

- Fix openAPIV3Schema for mcs and add kes validation. (fixes #125)