### PR TITLE
Fix bug due to empty ImagePullSecret

### DIFF
--- a/pkg/resources/statefulsets/minio-statefulset.go
+++ b/pkg/resources/statefulsets/minio-statefulset.go
@@ -361,7 +361,6 @@ func NewForMinIO(mi *miniov1.MinIOInstance, serviceName string) *appsv1.Stateful
 				Spec: corev1.PodSpec{
 					Containers:         containers,
 					Volumes:            podVolumes,
-					ImagePullSecrets:   []corev1.LocalObjectReference{mi.Spec.ImagePullSecret},
 					RestartPolicy:      corev1.RestartPolicyAlways,
 					Affinity:           mi.Spec.Affinity,
 					SchedulerName:      mi.Scheduler.Name,
@@ -371,6 +370,11 @@ func NewForMinIO(mi *miniov1.MinIOInstance, serviceName string) *appsv1.Stateful
 				},
 			},
 		},
+	}
+
+	// Address issue https://github.com/kubernetes/kubernetes/issues/85332
+	if mi.Spec.ImagePullSecret.Name != "" {
+		ss.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{mi.Spec.ImagePullSecret}
 	}
 
 	if mi.Spec.VolumeClaimTemplate != nil {


### PR DESCRIPTION
Set ImagePullSecret only if not empty.

Ref: https://github.com/kubernetes/kubernetes/issues/85332

Signed-off-by: Ritesh H Shukla <kerneltime@gmail.com>