### PR TITLE
Add a way to apply PodSecurityPolicy to MinIO Pods

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ MinIO-Operator brings native MinIO, [MCS](https://github.com/minio/mcs), and [KE
 | Automatic TLS for MinIO                                        | [Automatic TLS for MinIO Instance](https://github.com/minio/minio-operator/blob/master/docs/tls.md#automatic-csr-generation). |
 | Expand an existing MinIO cluster                               | [Expand a MinIO Cluster](https://github.com/minio/minio-operator/blob/master/docs/adding-zones.md). |
 | Use a custom template for hostname discovery                   | [Custom Hostname Discovery](https://github.com/minio/minio-operator/blob/master/docs/custom-name-templates.md). |
+| Use PodSecurityPolicy for MinIO Pods | [Apply PodSecurityPolicy](https://github.com/minio/minio-operator/blob/master/docs/pod-security-policy.md). |
 | Deploy MCS with MinIO cluster  | [Deploy MinIO Instance with MCS](https://github.com/minio/minio-operator/blob/master/docs/mcs.md). |
 | Deploy KES with MinIO cluster  | [Deploy MinIO Instance with KES](https://github.com/minio/minio-operator/blob/master/docs/kes.md). |
 

--- a/docs/pod-security-policy.md
+++ b/docs/pod-security-policy.md
@@ -1,0 +1,34 @@
+# Using PodSecurityPolicy for MinIO Pods
+
+[![Slack](https://slack.min.io/slack?type=svg)](https://slack.min.io)
+[![Docker Pulls](https://img.shields.io/docker/pulls/minio/k8s-operator.svg?maxAge=604800)](https://hub.docker.com/r/minio/k8s-operator)
+
+This document explains how to apply `PodSecurityPolicy` to MinIO Pods created by the MinIO Operator. A Pod Security Policy is a cluster-level resource that controls security sensitive aspects of the pod specification. Read more in [Kubernetes PodSecurityPolicy Documentation](https://kubernetes.io/docs/concepts/policy/pod-security-policy/).
+
+## Getting Started
+
+You can create a MinIO cluster with single zone, `zone-0` with 4 drives, with a custom `PodSecurityPolicy` applied to all the MinIO Pods created by the Operator.
+
+```
+kubectl create -f https://github.com/minio/minio-operator/tree/master/examples/minioinstance-pod-security-policy.yaml
+```
+
+This file creates a custom PodSecurityPolicy with these fields:
+
+```yaml
+privileged: false
+allowPrivilegeEscalation: false
+hostNetwork: true
+seLinux:
+  rule: RunAsAny
+supplementalGroups:
+  rule: RunAsAny
+runAsUser:
+  rule: RunAsAny
+fsGroup:
+  rule: RunAsAny
+volumes:
+  - '*'
+```
+
+Then it creates a `ClusterRole` attached to the `PodSecurityPolicy`. Finally a `ClusterRoleBinding` bounds the `ClusterRole` to a `ServiceAccount` which is added to all the MinIO Pods created by the MinIO Operator.

--- a/examples/minioinstance-pod-security-policy.yaml
+++ b/examples/minioinstance-pod-security-policy.yaml
@@ -1,0 +1,187 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-creds-secret
+type: Opaque
+data:
+  accesskey: bWluaW8= # base 64 encoded "minio" (echo -n 'minio' | base64)
+  secretkey: bWluaW8xMjM= # based 64 encoded "minio123" (echo -n 'minio123' | base64)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio-service
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9000
+      targetPort: 9000
+      protocol: TCP
+      # Optional field
+      # By default and for convenience, the Kubernetes control plane will allocate a port from a range (default: 30000-32767)
+      # nodePort: 30007
+  selector:
+    app: minio
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: minio-pods
+  namespace: default
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: minio-pods-policy
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  hostNetwork: true
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  fsGroup:
+    rule: RunAsAny
+  volumes:
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: minio-pods-role
+rules:
+- apiGroups: 
+  - "policy"
+  resources: 
+  - "podsecuritypolicies"
+  verbs: 
+  - "use"
+  resourceNames:
+  - "minio-pods-policy"
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: minio-pods-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: minio-pods-role
+subjects:
+- kind: ServiceAccount
+  name: minio-pods
+  namespace: default
+---
+apiVersion: operator.min.io/v1
+kind: MinIOInstance
+metadata:
+  name: minio
+## If specified, MinIOInstance pods will be dispatched by specified scheduler.
+## If not specified, the pod will be dispatched by default scheduler.
+# scheduler:
+#  name: my-custom-scheduler
+spec:
+  ## Add metadata to the all pods created by the StatefulSet
+  metadata:
+    ## Optionally pass labels to be applied to the statefulset pods
+    labels:
+      app: minio
+    annotations:
+      prometheus.io/path: /minio/prometheus/metrics
+      prometheus.io/port: "9000"
+      prometheus.io/scrape: "true"
+  ## Registry location and Tag to download MinIO Server image
+  image: minio/minio:RELEASE.2020-06-03T22-13-49Z
+  ## A ClusterIP Service will be created with the given name
+  serviceName: minio-internal-service
+  ## Service account to be used for all the MinIO Pods
+  serviceAccountName: minio-pods
+  zones:
+    - name: "zone-0"
+      ## Number of MinIO servers/pods in this zone.
+      ## For standalone mode, supply 1. For distributed mode, supply 4 or more.
+      ## Note that the operator does not support upgrading from standalone to distributed mode.
+      servers: 4
+  ## Supply number of volumes to be mounted per MinIO server instance.
+  volumesPerServer: 4
+  ## Mount path where PV will be mounted inside container(s). Defaults to "/export".
+  mountPath: /export
+  ## Sub path inside Mount path where MinIO starts. Defaults to "".
+  # subPath: /data
+  ## This VolumeClaimTemplate is used across all the volumes provisioned for MinIO cluster.
+  ## Please do not change the volumeClaimTemplate field while expanding the cluster, this may
+  ## lead to unbound PVCs and missing data
+  volumeClaimTemplate:
+    metadata:
+      name: data
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 1Ti
+  ## Secret with credentials to be used by MinIO instance.
+  credsSecret:
+    name: minio-creds-secret
+  ## PodManagement policy for pods created by StatefulSet. Can be "OrderedReady" or "Parallel"
+  ## Refer https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#pod-management-policy
+  ## for details. Defaults to "Parallel"
+  ## If set to "OrderedReady", then disable Readiness checks below. Readiness check will only
+  ## work if PodManagementPolicy is set to "Parallel".
+  podManagementPolicy: Parallel
+  ## Secret with certificates to configure TLS for MinIO certs. Create secrets as explained
+  ## here: https://github.com/minio/minio/tree/master/docs/tls/kubernetes#2-create-kubernetes-secret
+  # externalCertSecret:
+  # name: tls-ssl-minio
+  ## Enable Kubernetes based certificate generation and signing as explained in
+  ## https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster
+  requestAutoCert: false
+  ## Used when "requestAutoCert" is set to true. Set CommonName for the auto-generated certificate.
+  ## Internal DNS name for the pod will be used if CommonName is not provided.
+  ## DNS name format is minio-{0...3}.minio.default.svc.cluster.local
+  certConfig:
+    commonName: ""
+    organizationName: []
+    dnsNames: []
+  ## Used to specify a toleration for a pod
+  # tolerations:
+  #  - effect: NoSchedule
+  #    key: dedicated
+  #    operator: Equal
+  #    value: storage
+  ## Add environment variables to be set in MinIO container (https://github.com/minio/minio/tree/master/docs/config)
+  # env:
+    # - name: MINIO_BROWSER
+    #  value: "off" # to turn-off browser
+    # - name: MINIO_STORAGE_CLASS_STANDARD
+    #   value: "EC:2"
+  ## Configure resource requests and limits for MinIO containers
+  # resources:
+    # requests:
+      # memory: 20Gi
+  ## Liveness probe detects situations where MinIO server instance
+  ## is not working properly and needs restart. Kubernetes automatically
+  ## restarts the pods if liveness checks fail.
+  liveness:
+    initialDelaySeconds: 120
+    periodSeconds: 60
+  ## Readiness probe detects situations when MinIO server instance
+  ## is not ready to accept traffic. Kubernetes doesn't forward
+  ## traffic to the pod while readiness checks fail.
+  ## Readiness check will only work if PodManagementPolicy is set to "Parallel".
+  ## Disable this check if you're setting PodManagementPolicy to "OrderedReady".
+  readiness:
+    initialDelaySeconds: 120
+    periodSeconds: 60
+  ## nodeSelector parameters for MinIO Pods. It specifies a map of key-value pairs. For the pod to be
+  ## eligible to run on a node, the node must have each of the
+  ## indicated key-value pairs as labels.
+  ## Read more here: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  # nodeSelector:
+  #   disktype: ssd
+  ## Affinity settings for MinIO pods. Read more about affinity
+  ## here: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity.
+  # affinity:

--- a/minio-operator.yaml
+++ b/minio-operator.yaml
@@ -161,7 +161,7 @@ rules:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: minio-operator-sa
+  name: minio-operator
   namespace: default
 ---
 kind: ClusterRoleBinding
@@ -174,7 +174,7 @@ roleRef:
   name: minio-operator-role
 subjects:
 - kind: ServiceAccount
-  name: minio-operator-sa
+  name: minio-operator
   namespace: default
 ---
 apiVersion: apps/v1
@@ -192,7 +192,7 @@ spec:
       labels:
         name: minio-operator
     spec:
-      serviceAccountName: minio-operator-sa
+      serviceAccountName: minio-operator
       containers:
         - name: minio-operator
           image: minio/k8s-operator:2.0.5

--- a/pkg/apis/operator.min.io/v1/helper.go
+++ b/pkg/apis/operator.min.io/v1/helper.go
@@ -218,7 +218,7 @@ func (mi *MinIOInstance) MinIOHosts() []string {
 	// Create the ellipses style URL
 	for _, z := range mi.Spec.Zones {
 		max = max + z.Servers
-		hosts = append(hosts, fmt.Sprintf("%s-%s.%s.%s.svc.%s", ellipsis(int(index), int(max)-1), mi.MinIOStatefulSetName(), mi.MinIOHLServiceName(), mi.Namespace, ClusterDomain))
+		hosts = append(hosts, fmt.Sprintf("%s-%s.%s.%s.svc.%s", mi.MinIOStatefulSetName(), ellipsis(int(index), int(max)-1), mi.MinIOHLServiceName(), mi.Namespace, ClusterDomain))
 		index = max
 	}
 	return hosts


### PR DESCRIPTION
This PR also fixes a regression introduced in #130 where incorrect
arguements are passed to MinIO containers.