### PR TITLE
Fix NPE on Main Controller

### DIFF
--- a/pkg/controller/cluster/main-controller.go
+++ b/pkg/controller/cluster/main-controller.go
@@ -344,8 +344,12 @@ func (c *Controller) syncHandler(key string) error {
 
 	// Validate the MinIO Instance
 	if err = mi.Validate(); err != nil {
-		mi, err = c.updateMinIOInstanceStatus(ctx, mi, err.Error(), 0)
 		klog.V(2).Infof(err.Error())
+		var err2 error
+		mi, err2 = c.updateMinIOInstanceStatus(ctx, mi, err.Error(), 0)
+		if err2 != nil {
+			klog.V(2).Infof(err2.Error())
+		}
 		return err
 	}
 


### PR DESCRIPTION
Fixes an NPE on main controller after the validation fails with an error, then the status is updated for the minio instance, returning the error to nil and causing an NPE, the prophet @harshavardhana foresaw this