### PR TITLE
fix indentation issue in manual PV template

### DIFF
--- a/docs/creating-pv-manually.md
+++ b/docs/creating-pv-manually.md
@@ -37,12 +37,12 @@ spec:
     path: /mnt/disks/ssd1
   nodeAffinity:
     required:
-    nodeSelectorTerms:
-    - matchExpressions:
-      - key: kubernetes.io/hostname
-        operator: In
-        values:
-        - example-node
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - example-node
 ```
 
 After configuring the PV details, use `kubectl` to create the requisite number of PVs.


### PR DESCRIPTION
The node affinity section of the sample PV yaml was missing an indenation level. This meant the sample failed validation.

This adds the required indentation level.