### PR TITLE
Tweak the default values in examples.

### DIFF
--- a/examples/minioinstance-kes.yaml
+++ b/examples/minioinstance-kes.yaml
@@ -145,18 +145,18 @@ spec:
   ## is not working properly and needs restart. Kubernetes automatically
   ## restarts the pods if liveness checks fail.
   liveness:
-    initialDelaySeconds: 120
-    periodSeconds: 15
-    timeoutSeconds: 12 # should always greater than MINIO_API_READY_DEADLINE (which defaults to 10s)
+    initialDelaySeconds: 1
+    periodSeconds: 1
+    timeoutSeconds: 60 # should always greater than MINIO_API_READY_DEADLINE (which defaults to 10s)
   ## Readiness probe detects situations when MinIO server instance
   ## is not ready to accept traffic. Kubernetes doesn't forward
   ## traffic to the pod while readiness checks fail.
   ## Readiness check will only work if PodManagementPolicy is set to "Parallel".
   ## Disable this check if you're setting PodManagementPolicy to "OrderedReady".
   readiness:
-    initialDelaySeconds: 120
-    periodSeconds: 15
-    timeoutSeconds: 1
+    initialDelaySeconds: 1
+    periodSeconds: 1
+    timeoutSeconds: 60
   ## nodeSelector parameters for MinIO Pods. It specifies a map of key-value pairs. For the pod to be
   ## eligible to run on a node, the node must have each of the
   ## indicated key-value pairs as labels.

--- a/examples/minioinstance-mcs.yaml
+++ b/examples/minioinstance-mcs.yaml
@@ -132,18 +132,18 @@ spec:
   ## is not working properly and needs restart. Kubernetes automatically
   ## restarts the pods if liveness checks fail.
   liveness:
-    initialDelaySeconds: 120
-    periodSeconds: 15
-    timeoutSeconds: 12 # should always greater than MINIO_API_READY_DEADLINE (which defaults to 10s)
+    initialDelaySeconds: 1
+    periodSeconds: 1
+    timeoutSeconds: 60 # should always greater than MINIO_API_READY_DEADLINE (which defaults to 10s)
   ## Readiness probe detects situations when MinIO server instance
   ## is not ready to accept traffic. Kubernetes doesn't forward
   ## traffic to the pod while readiness checks fail.
   ## Readiness check will only work if PodManagementPolicy is set to "Parallel".
   ## Disable this check if you're setting PodManagementPolicy to "OrderedReady".
   readiness:
-    initialDelaySeconds: 120
-    periodSeconds: 15
-    timeoutSeconds: 1
+    initialDelaySeconds: 1
+    periodSeconds: 1
+    timeoutSeconds: 60
   ## nodeSelector parameters for MinIO Pods. It specifies a map of key-value pairs. For the pod to be
   ## eligible to run on a node, the node must have each of the
   ## indicated key-value pairs as labels.

--- a/examples/minioinstance-pod-security-policy.yaml
+++ b/examples/minioinstance-pod-security-policy.yaml
@@ -166,16 +166,18 @@ spec:
   ## is not working properly and needs restart. Kubernetes automatically
   ## restarts the pods if liveness checks fail.
   liveness:
-    initialDelaySeconds: 120
-    periodSeconds: 60
+    initialDelaySeconds: 1
+    periodSeconds: 1
+    timeoutSeconds: 60
   ## Readiness probe detects situations when MinIO server instance
   ## is not ready to accept traffic. Kubernetes doesn't forward
   ## traffic to the pod while readiness checks fail.
   ## Readiness check will only work if PodManagementPolicy is set to "Parallel".
   ## Disable this check if you're setting PodManagementPolicy to "OrderedReady".
   readiness:
-    initialDelaySeconds: 120
-    periodSeconds: 60
+    initialDelaySeconds: 1
+    periodSeconds: 1
+    timeoutSeconds: 60
   ## nodeSelector parameters for MinIO Pods. It specifies a map of key-value pairs. For the pod to be
   ## eligible to run on a node, the node must have each of the
   ## indicated key-value pairs as labels.

--- a/examples/minioinstance.yaml
+++ b/examples/minioinstance.yaml
@@ -114,18 +114,18 @@ spec:
   ## is not working properly and needs restart. Kubernetes automatically
   ## restarts the pods if liveness checks fail.
   liveness:
-    initialDelaySeconds: 120
-    periodSeconds: 15
-    timeoutSeconds: 12 # should always greater than MINIO_API_READY_DEADLINE (which defaults to 10s)
+    initialDelaySeconds: 1
+    periodSeconds: 1
+    timeoutSeconds: 60 # should always greater than MINIO_API_READY_DEADLINE (which defaults to 10s)
   ## Readiness probe detects situations when MinIO server instance
   ## is not ready to accept traffic. Kubernetes doesn't forward
   ## traffic to the pod while readiness checks fail.
   ## Readiness check will only work if PodManagementPolicy is set to "Parallel".
   ## Disable this check if you're setting PodManagementPolicy to "OrderedReady".
   readiness:
-    initialDelaySeconds: 120
-    periodSeconds: 15
-    timeoutSeconds: 1
+    initialDelaySeconds: 1
+    periodSeconds: 1
+    timeoutSeconds: 60
   ## nodeSelector parameters for MinIO Pods. It specifies a map of key-value pairs. For the pod to be
   ## eligible to run on a node, the node must have each of the
   ## indicated key-value pairs as labels.


### PR DESCRIPTION
Reduce the delay before minio is checked for readiness and liveness
and make it more eager.

Signed-off-by: Ritesh H Shukla <ritesh@minio.io>