### PR TITLE
Use wildcard certificates for MinIO Pods

### DIFF
--- a/docs/kes.md
+++ b/docs/kes.md
@@ -47,11 +47,4 @@ KES uses CSR for self signed certificate generation. KES requires three certific
 - X.509 certificate for the MinIO server and the corresponding private key.
 - X.509 certificate for the KES client (MinIO is the KES client in this case) and the corresponding private key.
 
-Accordingly, you'll need to approve three CSR requests, using below approach
-
-```
-kubectl get csr
-kubectl certificate approve <csr-name>
-```
-
-Once all the CSRs are approved, MinIO Operator will deploy KES Pods and start MinIO Server with KES integration.
+If `requestAutoCert` is enabled, Operator automatically creates the relevant CSRs and Certificates.

--- a/docs/tls.md
+++ b/docs/tls.md
@@ -7,7 +7,7 @@ This document explains how to enable TLS on MinIOInstance pods. These are the ap
 
 ## Automatic TLS
 
-This approach creates TLS certificates automatically using the Kubernetes cluster root Certificate Authority (CA) to establish trust. In this approach, MinIO Operator creates a private key, and a certificate signing request (CSR) which is submitted via the `certificates.k8s.io` API for signing. Approving the CSR is done on a one off basis by a Kubernetes cluster administrator. Automatic TLS approach creates other certificates required for KES as well as explained in [KES document](./kes.md).
+This approach creates TLS certificates automatically using the Kubernetes cluster root Certificate Authority (CA) to establish trust. In this approach, MinIO Operator creates a private key, and a certificate signing request (CSR) which is submitted via the `certificates.k8s.io` API for signing. Automatic TLS approach creates other certificates required for KES as well as explained in [KES document](./kes.md).
 
 To enable automatic CSR generation on MinIOInstance, set `requestAutoCert` field in the config file to `true`. Optionally you can also pass additional configuration parameters to be used under `certConfig` section. The `certConfig` section currently supports below fields:
 
@@ -17,21 +17,7 @@ To enable automatic CSR generation on MinIOInstance, set `requestAutoCert` field
 
 - DNSNames: By default set to list of all pod DNS names that are part of current MinIOInstance cluster. Any value added under this section will be appended to the list of existing pod DNS names.
 
-Once you enable `requestAutoCert` field and create the MinIOInstance, MinIO Operator creates a CSR for this instance and sends to the Kubernetes API server. MinIO Operator will then wait for the CSR to be approved (wait timeout is 20 minutes). CSR can be approved manually via `kubectl` using below steps
-
-- Get the CSR
-
-```bash
-kubectl get csr
-```
-
-- Approve the CSR
-
-```bash
-kubectl certificate approve <CSR_Name>
-```
-
-Once the CSR is approved and Certificate available, MinIO operator downloads the certificate and then mounts the Private Key and Certificate within the MinIOInstance pod.
+Once you enable `requestAutoCert` field and create the MinIOInstance, MinIO Operator creates a CSR for this instance and sends to the Kubernetes API server. MinIO Operator will then approve the CSR. After the CSR is approved and Certificate available, MinIO operator downloads the certificate and then mounts the Private Key and Certificate within the MinIOInstance pod.
 
 ## Pass Certificate Secret to MinIOInstance
 

--- a/pkg/apis/operator.min.io/v1/helper.go
+++ b/pkg/apis/operator.min.io/v1/helper.go
@@ -274,16 +274,8 @@ func (mi *MinIOInstance) TemplatedMinIOHosts(hostsTemplate string) []string {
 // AllMinIOHosts returns the all the individual domain names relevant for current MinIOInstance
 func (mi *MinIOInstance) AllMinIOHosts() []string {
 	hosts := make([]string, 0)
-	var max, index int32
-	for _, z := range mi.Spec.Zones {
-		max = max + z.Servers
-		for index < max {
-			hosts = append(hosts, fmt.Sprintf("%s-"+strconv.Itoa(int(index))+".%s.%s.svc.%s", mi.MinIOStatefulSetName(), mi.MinIOHLServiceName(), mi.Namespace, ClusterDomain))
-			index++
-		}
-	}
 	hosts = append(hosts, mi.MinIOCIServiceHost())
-	hosts = append(hosts, mi.MinIOHeadlessServiceHost())
+	hosts = append(hosts, "*."+mi.MinIOHeadlessServiceHost())
 	return hosts
 }
 

--- a/pkg/controller/cluster/kes-csr.go
+++ b/pkg/controller/cluster/kes-csr.go
@@ -72,7 +72,7 @@ func (c *Controller) createKESTLSCSR(ctx context.Context, mi *miniov1.MinIOInsta
 		return err
 	}
 
-	err = c.submitCSR(ctx, mi.KESPodLabels(), mi.KESCSRName(), mi.Namespace, csrBytes, mi)
+	err = c.createCertificate(ctx, mi.KESPodLabels(), mi.KESCSRName(), mi.Namespace, csrBytes, mi)
 	if err != nil {
 		klog.Errorf("Unexpected error during the creation of the csr/%s: %v", mi.KESCSRName(), err)
 		return err
@@ -107,7 +107,7 @@ func (c *Controller) createMinIOClientTLSCSR(ctx context.Context, mi *miniov1.Mi
 		return err
 	}
 
-	err = c.submitCSR(ctx, mi.MinIOPodLabels(), mi.MinIOClientCSRName(), mi.Namespace, csrBytes, mi)
+	err = c.createCertificate(ctx, mi.MinIOPodLabels(), mi.MinIOClientCSRName(), mi.Namespace, csrBytes, mi)
 	if err != nil {
 		klog.Errorf("Unexpected error during the creation of the csr/%s: %v", mi.MinIOClientCSRName(), err)
 		return err


### PR DESCRIPTION
Wildcard certificates for pods ensure there is no need to create
new certificates during zone addition, making the process seamless.

This PR also adds automatic CSR Approval for the CSR created
during MinIO / KES deployment. This avoids human intervention
to approve CSRs manually.