### PR TITLE
Support for MinIO Disco

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ data:
 ```
 Afterwards, restart the coredns pods on the `kube-system` namespace
 ```bash
-$ kubectl -n kube-system delete pod $(kubectl -n kube-system get pods  | grep coredns | awk '{print $1}')
+$ kubectl rollout restart -n kube-system deployment coredns
 ```
 
 Advanced users can leverage [kustomize](https://github.com/kubernetes-sigs/kustomize) to customize operator configuration

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.13
 require (
 	github.com/evanphx/json-patch v4.5.0+incompatible // indirect
 	github.com/golang/protobuf v1.3.3 // indirect
-	github.com/imdario/mergo v0.3.6 // indirect
 	github.com/minio/minio v0.0.0-20200501124117-09571d03a531
 	github.com/stretchr/testify v1.4.0
 	golang.org/x/net v0.0.0-20200505041828-1ed23360d12c // indirect

--- a/go.sum
+++ b/go.sum
@@ -181,8 +181,6 @@ github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/imdario/mergo v0.3.5 h1:JboBksRwiiAJWvIYJVo46AfV+IAIKZpfrSzVKj42R4Q=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
-github.com/imdario/mergo v0.3.6 h1:xTNEAn+kxVO7dTZGu0CegyqKZmoWFI0rF8UxjlB2d28=
-github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/go-update v0.0.0-20160112193335-8152e7eb6ccf/go.mod h1:hyb9oH7vZsitZCiBt0ZvifOrB+qc8PS5IiilCIb87rg=
 github.com/jcmturner/gofork v0.0.0-20190328161633-dc7c13fece03/go.mod h1:MK8+TM0La+2rjBD4jE12Kj1pCCxK7d2LK/UM3ncEo0o=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
@@ -421,6 +419,7 @@ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 h1:YUO/7uOKsKeq9UokNS62b8FY
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/minio-operator.yaml
+++ b/minio-operator.yaml
@@ -174,7 +174,7 @@ spec:
             - /disco
             - server
           image: minio/disco:v0.0.1
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           name: minio-disco
           ports:
             - containerPort: 53

--- a/minio-operator.yaml
+++ b/minio-operator.yaml
@@ -173,7 +173,7 @@ spec:
         - args:
             - /disco
             - server
-          image: dvaldivia/disco:latest
+          image: minio/disco:latest
           imagePullPolicy: Always
           name: minio-disco
           ports:

--- a/minio-operator.yaml
+++ b/minio-operator.yaml
@@ -90,6 +90,101 @@ spec:
           type: string
           jsonPath: ".status.currentState"
 ---
+#Service Discovery
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: minio-disco-sa
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: minio-disco-sa-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+      - pods
+      - services
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups:
+      - operator.min.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - min.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: minio-disco-sa-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: minio-disco-sa-role
+subjects:
+  - kind: ServiceAccount
+    name: minio-disco-sa
+    namespace: default
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: minio-disco
+  name: minio-disco
+spec:
+  ports:
+    - name: dns
+      port: 53
+      protocol: UDP
+    - name: dns-tcp
+      port: 53
+      protocol: TCP
+  selector:
+    app: minio-disco
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio-disco
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio-disco
+  template:
+    metadata:
+      labels:
+        app: minio-disco
+    spec:
+      containers:
+        - args:
+            - /disco
+            - server
+          image: dvaldivia/disco:latest
+          imagePullPolicy: Always
+          name: minio-disco
+          ports:
+            - containerPort: 53
+              name: dns
+              protocol: UDP
+            - containerPort: 53
+              name: dns-tcp
+              protocol: TCP
+      serviceAccountName: minio-disco-sa
+---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:

--- a/minio-operator.yaml
+++ b/minio-operator.yaml
@@ -173,7 +173,7 @@ spec:
         - args:
             - /disco
             - server
-          image: minio/disco:latest
+          image: minio/disco:v0.0.1
           imagePullPolicy: Always
           name: minio-disco
           ports:

--- a/pkg/apis/operator.min.io/v1/constants.go
+++ b/pkg/apis/operator.min.io/v1/constants.go
@@ -41,7 +41,7 @@ const DefaultPodManagementPolicy = appsv1.ParallelPodManagement
 const DefaultUpdateStrategy = "RollingUpdate"
 
 // DefaultImagePullPolicy specifies the policy to image pulls
-const DefaultImagePullPolicy = "Always"
+const DefaultImagePullPolicy = corev1.PullIfNotPresent
 
 // CSRNameSuffix specifies the suffix added to MinIOInstance name to create a CSR
 const CSRNameSuffix = "-csr"
@@ -180,3 +180,7 @@ var DefaultQueryTimeout = time.Minute * 20
 
 // TLSSecretSuffix is the suffix applied to MinIOInstance name to create the TLS secret
 var TLSSecretSuffix = "-tls"
+
+// Service Discovery
+var discoSvcName = "minio-disco"
+var discoProbeDomain = "probe.minio.local"

--- a/pkg/apis/operator.min.io/v1/globals.go
+++ b/pkg/apis/operator.min.io/v1/globals.go
@@ -34,7 +34,7 @@ var Identity string
 func getEnv(key string) string {
 	value, ok := os.LookupEnv(key)
 	if !ok {
-		return "cluster.local"
+		return "minio.local"
 	}
 	return value
 }

--- a/pkg/apis/operator.min.io/v1/helper.go
+++ b/pkg/apis/operator.min.io/v1/helper.go
@@ -256,8 +256,6 @@ func (mi *MinIOInstance) TemplatedMinIOHosts(hostsTemplate string) []string {
 		if err = tmpl.Execute(output, data); err != nil {
 			continue
 		}
-		fmt.Println("output.String()")
-		fmt.Println(output.String())
 		hosts = append(hosts, output.String())
 		index = max
 	}

--- a/pkg/apis/operator.min.io/v1/helper.go
+++ b/pkg/apis/operator.min.io/v1/helper.go
@@ -220,10 +220,11 @@ func (mi *MinIOInstance) EnsureDefaults() *MinIOInstance {
 func (mi *MinIOInstance) MinIOHosts() []string {
 	hosts := make([]string, 0)
 	var max, index int32
+	hostPostfix := mi.HostPostfix()
 	// Create the ellipses style URL
 	for _, z := range mi.Spec.Zones {
 		max = max + z.Servers
-		hosts = append(hosts, fmt.Sprintf("%s-%s.%s.%s.svc.%s", mi.MinIOStatefulSetName(), ellipsis(int(index), int(max)-1), mi.MinIOHLServiceName(), mi.Namespace, ClusterDomain))
+		hosts = append(hosts, fmt.Sprintf("%s-%s.%s", mi.MinIOStatefulSetName(), ellipsis(int(index), int(max)-1), hostPostfix))
 		index = max
 	}
 	return hosts
@@ -259,14 +260,20 @@ func (mi *MinIOInstance) TemplatedMinIOHosts(hostsTemplate string) []string {
 	return hosts
 }
 
+// HostPostfix returns the last part of the host `service.minio.local` used ie: `instance.service.minio.local`
+func (mi *MinIOInstance) HostPostfix() string {
+	return fmt.Sprintf("%s.%s", mi.MinIOHLServiceName(), ClusterDomain)
+}
+
 // AllMinIOHosts returns the all the individual domain names relevant for current MinIOInstance
 func (mi *MinIOInstance) AllMinIOHosts() []string {
+	topLevelHostURL := mi.HostPostfix()
 	hosts := make([]string, 0)
 	var max, index int32
 	for _, z := range mi.Spec.Zones {
 		max = max + z.Servers
 		for index < max {
-			hosts = append(hosts, fmt.Sprintf("%s-"+strconv.Itoa(int(index))+".%s.%s.svc.%s", mi.MinIOStatefulSetName(), mi.MinIOHLServiceName(), mi.Namespace, ClusterDomain))
+			hosts = append(hosts, fmt.Sprintf("%s-"+strconv.Itoa(int(index))+".%s", mi.MinIOStatefulSetName(), topLevelHostURL))
 			index++
 		}
 	}

--- a/pkg/apis/operator.min.io/v1/helper.go
+++ b/pkg/apis/operator.min.io/v1/helper.go
@@ -264,7 +264,7 @@ func (mi *MinIOInstance) TemplatedMinIOHosts(hostsTemplate string) []string {
 
 // HostPostfix returns the last part of the host `service.minio.local` used ie: `instance.service.minio.local`
 func (mi *MinIOInstance) HostPostfix() string {
-	return fmt.Sprintf("%s.%s", mi.MinIOHLServiceName(), ClusterDomain)
+	return fmt.Sprintf("%s.%s.%s", mi.MinIOHLServiceName(), mi.Namespace, ClusterDomain)
 }
 
 // AllMinIOHosts returns the all the individual domain names relevant for current MinIOInstance

--- a/pkg/apis/operator.min.io/v1/labels.go
+++ b/pkg/apis/operator.min.io/v1/labels.go
@@ -24,6 +24,13 @@ func (mi *MinIOInstance) MinIOPodLabels() map[string]string {
 	return m
 }
 
+// MinIOPodAnnotations returns the default annotations for MinIO Pod
+func (mi *MinIOInstance) MinIOPodAnnotations() map[string]string {
+	m := make(map[string]string, 1)
+	m[InstanceLabel] = mi.MinIOStatefulSetName()
+	return m
+}
+
 // KESPodLabels returns the default labels for KES Pod
 func (mi *MinIOInstance) KESPodLabels() map[string]string {
 	m := make(map[string]string, 1)

--- a/pkg/apis/operator.min.io/v1/labels.go
+++ b/pkg/apis/operator.min.io/v1/labels.go
@@ -24,13 +24,6 @@ func (mi *MinIOInstance) MinIOPodLabels() map[string]string {
 	return m
 }
 
-// MinIOPodAnnotations returns the default annotations for MinIO Pod
-func (mi *MinIOInstance) MinIOPodAnnotations() map[string]string {
-	m := make(map[string]string, 1)
-	m[InstanceLabel] = mi.MinIOStatefulSetName()
-	return m
-}
-
 // KESPodLabels returns the default labels for KES Pod
 func (mi *MinIOInstance) KESPodLabels() map[string]string {
 	m := make(map[string]string, 1)

--- a/pkg/controller/cluster/main-controller.go
+++ b/pkg/controller/cluster/main-controller.go
@@ -500,8 +500,16 @@ func (c *Controller) syncHandler(key string) error {
 			if err != nil {
 				return err
 			}
+
+			discoSvc, err := c.kubeClientSet.
+				CoreV1().
+				Services(mi.Namespace).
+				Get(context.Background(), discoSvcName, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
 			// Create a new statefulset object and send an update request
-			ss = statefulsets.NewForMinIO(mi, hlSvc.Name, c.hostsTemplate)
+			ss = statefulsets.NewForMinIO(mi, hlSvc.Name, c.hostsTemplate, discoSvc.Spec.ClusterIP)
 			if _, err := c.kubeClientSet.AppsV1().StatefulSets(mi.Namespace).Update(ctx, ss, uOpts); err != nil {
 				return err
 			}

--- a/pkg/controller/cluster/main-controller.go
+++ b/pkg/controller/cluster/main-controller.go
@@ -62,6 +62,7 @@ import (
 )
 
 const controllerAgentName = "minio-operator"
+const discoSvcName = "minio-disco"
 
 const (
 	// SuccessSynced is used as part of the Event 'reason' when a MinIOInstance is synced
@@ -456,7 +457,7 @@ func (c *Controller) syncHandler(key string) error {
 			svc, err := c.kubeClientSet.
 				CoreV1().
 				Services(mi.Namespace).
-				Get(context.Background(), "mindns", metav1.GetOptions{})
+				Get(context.Background(), discoSvcName, metav1.GetOptions{})
 			if err != nil {
 				return err
 			}
@@ -518,7 +519,7 @@ func (c *Controller) syncHandler(key string) error {
 			minsvc, err := c.kubeClientSet.
 				CoreV1().
 				Services(mi.Namespace).
-				Get(context.Background(), "mindns", metav1.GetOptions{})
+				Get(context.Background(), discoSvcName, metav1.GetOptions{})
 			if err != nil {
 				log.Println(err)
 			}

--- a/pkg/controller/cluster/main-controller.go
+++ b/pkg/controller/cluster/main-controller.go
@@ -454,7 +454,7 @@ func (c *Controller) syncHandler(key string) error {
 				return err
 			}
 
-			svc, err := c.kubeClientSet.
+			discoSvc, err := c.kubeClientSet.
 				CoreV1().
 				Services(mi.Namespace).
 				Get(context.Background(), discoSvcName, metav1.GetOptions{})
@@ -462,7 +462,7 @@ func (c *Controller) syncHandler(key string) error {
 				return err
 			}
 
-			ss = statefulsets.NewForMinIO(mi, hlSvc.Name, c.hostsTemplate, svc.Spec.ClusterIP)
+			ss = statefulsets.NewForMinIO(mi, hlSvc.Name, c.hostsTemplate, discoSvc.Spec.ClusterIP)
 			ss, err = c.kubeClientSet.AppsV1().StatefulSets(mi.Namespace).Create(ctx, ss, cOpts)
 			if err != nil {
 				return err
@@ -516,14 +516,14 @@ func (c *Controller) syncHandler(key string) error {
 				return err
 			}
 			klog.V(4).Infof("Updating MinIOInstance %s MinIO server version %s, to: %s", name, mi.Spec.Image, ss.Spec.Template.Spec.Containers[0].Image)
-			minsvc, err := c.kubeClientSet.
+			minSvc, err := c.kubeClientSet.
 				CoreV1().
 				Services(mi.Namespace).
 				Get(context.Background(), discoSvcName, metav1.GetOptions{})
 			if err != nil {
 				log.Println(err)
 			}
-			ss = statefulsets.NewForMinIO(mi, hlSvc.Name, c.hostsTemplate, minsvc.Spec.ClusterIP)
+			ss = statefulsets.NewForMinIO(mi, hlSvc.Name, c.hostsTemplate, minSvc.Spec.ClusterIP)
 			if _, err := c.kubeClientSet.AppsV1().StatefulSets(mi.Namespace).Update(ctx, ss, uOpts); err != nil {
 				return err
 			}

--- a/pkg/resources/statefulsets/minio-statefulset.go
+++ b/pkg/resources/statefulsets/minio-statefulset.go
@@ -391,7 +391,6 @@ func NewForMinIO(mi *miniov1.MinIOInstance, serviceName string, hostsTemplate st
 		}
 	}
 
-
 	// configure the pod to register into disco
 	if ss.Spec.Template.ObjectMeta.Annotations == nil {
 		ss.Spec.Template.ObjectMeta.Annotations = map[string]string{}

--- a/pkg/resources/statefulsets/minio-statefulset.go
+++ b/pkg/resources/statefulsets/minio-statefulset.go
@@ -391,10 +391,10 @@ func NewForMinIO(mi *miniov1.MinIOInstance, serviceName string, hostsTemplate st
 		}
 	}
 
-	if _, ok := ss.Spec.Template.ObjectMeta.Annotations["io.min.dns"]; ok {
+	// if the instance has io.min.disco annotation, then we know we should configure the dns for the pods as well
+	if _, ok := ss.Spec.Template.ObjectMeta.Annotations["io.min.disco"]; ok {
 		// get the IP of the MinDNS if it's deployed
-
-		ss.Spec.Template.ObjectMeta.Annotations["io.min.dns"] = fmt.Sprintf("{.metadata.name}.%s", mi.MinIOHLServiceName())
+		ss.Spec.Template.ObjectMeta.Annotations["io.min.disco"] = fmt.Sprintf("{.metadata.name}.%s", mi.MinIOHLServiceName())
 		ss.Spec.Template.Spec.DNSPolicy = corev1.DNSNone
 		ss.Spec.Template.Spec.DNSConfig = &corev1.PodDNSConfig{
 			Nameservers: []string{minDNSIP},


### PR DESCRIPTION
Adds support for MinIO Disco

it defaults the start command for the statefulsets to the structure `instance-{0...X}.statefulset.minio.local`, this can be overriden with the argument `--hosts-template` for example `--hosts-template={{.StatefulSet}}-{{.Ellipsis}}.{{.HLService}}` would override this default.

Before creating a statefulset, we probe if `MinIO Disco` is configured globally, in case it's not, we get the IP of the `minio-disco` service and configure the statefulset to have a custom `dnsPolicy`