### PR TITLE
Update ClusterRole to allow for automatic signing

### DIFF
--- a/minio-operator.yaml
+++ b/minio-operator.yaml
@@ -226,6 +226,15 @@ rules:
       - get
       - delete
   - apiGroups:
+      - certificates.k8s.io
+    resourceNames:
+      - kubernetes.io/legacy-unknown
+    resources:
+      - signers
+    verbs:
+      - approve
+      - sign
+  - apiGroups:
       - minio.min.io
     resources:
       - '*'


### PR DESCRIPTION
To auto-approve certificates, additional rules need to be granted to the operator.
Ref: https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/

Also, Included a temporary workaround as well for the samples to work. @nitisht is looking into a fix. 

Signed-off-by: Ritesh H Shukla <ritesh@minio.io>