### PR TITLE
Fix TLS and CSR bugs

### DIFF
--- a/pkg/apis/minio.min.io/v1/constants.go
+++ b/pkg/apis/minio.min.io/v1/constants.go
@@ -101,6 +101,10 @@ const LivenessPeriod = 1
 // LivenessTimeout specifies the timeout for the liveness probe to expect a response
 const LivenessTimeout = 1
 
+// LivenessFailureThreshold specifies the number of times the liveness probe can fail before
+// the probe to be considered failed.
+const LivenessFailureThreshold = 1
+
 // Console Related Constants
 
 // DefaultConsoleImage specifies the latest Console Docker hub image

--- a/pkg/apis/minio.min.io/v1/globals.go
+++ b/pkg/apis/minio.min.io/v1/globals.go
@@ -24,9 +24,6 @@ import (
 // ClusterDomain is used to store the Kubernetes cluster domain
 var ClusterDomain string
 
-// Scheme indicates communication over http or https
-var Scheme string
-
 // Identity is the public identity generated for MinIO Server based on
 // Used only during KES Deployments
 var Identity string
@@ -39,16 +36,7 @@ func getEnv(key string) string {
 	return value
 }
 
-func identifyScheme(t *Tenant) string {
-	scheme := "http"
-	if t.AutoCert() || t.ExternalCert() {
-		scheme = "https"
-	}
-	return scheme
-}
-
 // InitGlobals initiates the global variables while Operator starts
 func InitGlobals(t *Tenant) {
 	ClusterDomain = getEnv("CLUSTER_DOMAIN")
-	Scheme = identifyScheme(t)
 }

--- a/pkg/apis/minio.min.io/v1/helper.go
+++ b/pkg/apis/minio.min.io/v1/helper.go
@@ -367,7 +367,7 @@ func (t *Tenant) NewMinIOAdmin(minioSecret map[string][]byte) (*madmin.AdminClie
 	}
 
 	opts := &madmin.Options{
-		Secure: Scheme == "https",
+		Secure: t.TLS(),
 		Creds:  credentials.NewStaticV4(string(accessKey), string(secretKey), ""),
 	}
 
@@ -537,4 +537,9 @@ func (t *Tenant) OwnerRef() []metav1.OwnerReference {
 			Kind:    MinIOCRDResourceKind,
 		}),
 	}
+}
+
+// TLS indicates whether TLS is enabled for this tenant
+func (t *Tenant) TLS() bool {
+	return t.AutoCert() || t.ExternalCert()
 }

--- a/pkg/apis/minio.min.io/v1/names.go
+++ b/pkg/apis/minio.min.io/v1/names.go
@@ -66,8 +66,9 @@ func (t *Tenant) MinIOCIServiceName() string {
 }
 
 // MinIOCSRName returns the name of CSR that is generated if AutoTLS is enabled
+// Namespace adds uniqueness to the CSR name (single MinIO tenant per namsepace) since, CSR is not a namespaced resource
 func (t *Tenant) MinIOCSRName() string {
-	return t.Name + CSRNameSuffix
+	return t.Name + t.Namespace + CSRNameSuffix
 }
 
 // MinIOClientCSRName returns the name of CSR that is generated for Client side authentication
@@ -111,8 +112,9 @@ func (t *Tenant) KESTLSSecretName() string {
 }
 
 // KESCSRName returns the name of CSR that generated if AutoTLS is enabled for KES
+// Namespace adds uniqueness to the CSR name (single KES tenant per namsepace) since, CSR is not a namespaced resource
 func (t *Tenant) KESCSRName() string {
-	return t.KESStatefulSetName() + CSRNameSuffix
+	return t.KESStatefulSetName() + t.Namespace + CSRNameSuffix
 }
 
 // Console Related Names

--- a/pkg/resources/deployments/console-deployment.go
+++ b/pkg/resources/deployments/console-deployment.go
@@ -29,13 +29,17 @@ import (
 
 // Adds required Console environment variables
 func consoleEnvVars(t *miniov1.Tenant) []corev1.EnvVar {
+	scheme := "http"
+	if t.TLS() {
+		scheme = "https"
+	}
 	envVars := []corev1.EnvVar{
 		{
 			Name:  "MCS_MINIO_SERVER",
-			Value: miniov1.Scheme + "://" + net.JoinHostPort(t.MinIOCIServiceHost(), strconv.Itoa(miniov1.MinIOPort)),
+			Value: scheme + "://" + net.JoinHostPort(t.MinIOCIServiceHost(), strconv.Itoa(miniov1.MinIOPort)),
 		},
 	}
-	if miniov1.Scheme == "https" {
+	if scheme == "https" {
 		envVars = append(envVars, corev1.EnvVar{
 			Name:  "MCS_MINIO_SERVER_TLS_SKIP_VERIFICATION",
 			Value: "on",


### PR DESCRIPTION
- Remove global TLS variable, instead use per tenant TLS method.

- Fix CSR name to be unique per namespace (hence per tenant). This
is required to avoid name collision because CSR is not a
namespaced resource.

- Use 1 as the failure threshold for Liveness probe. This is because
we should stop sending requests to a failed pod as soon as we detect
it.
