### PR TITLE
Fix Single instance Hostname

### DIFF
--- a/pkg/apis/minio.min.io/v1/helper.go
+++ b/pkg/apis/minio.min.io/v1/helper.go
@@ -278,11 +278,6 @@ func (t *Tenant) AllMinIOHosts() []string {
 
 // MinIOCIServiceHost returns ClusterIP service Host for current Tenant
 func (t *Tenant) MinIOCIServiceHost() string {
-	if t.Spec.Zones[0].Servers == 1 {
-		msg := "Please set the server count > 1"
-		klog.V(2).Infof(msg)
-		return ""
-	}
 	return fmt.Sprintf("%s.%s.svc.%s", t.MinIOCIServiceName(), t.Namespace, ClusterDomain)
 }
 


### PR DESCRIPTION
We had a bug where a single zone single server deployment could not initialize it's Console because `MinIOCIServiceHost()` returned empty for single instance. This function is used in multiple places that expect a proper hostname to be returned.